### PR TITLE
chore: integrate supabase typings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,24 @@
+# Contributing
+
+Thank you for investing time in Hipotrack! The guidelines below highlight the workflow for keeping Supabase types and the application schema in sync.
+
+## Supabase type generation
+
+1. **Install the Supabase CLI** if you haven't already. Follow the official instructions at <https://supabase.com/docs/reference/cli/installation>.
+2. **Authenticate with Supabase** (`supabase login`) so that the CLI can access your project.
+3. **Expose the project identifier** locally before generating types:
+   ```bash
+   export SUPABASE_PROJECT_ID=your_project_id
+   ```
+   For CI environments, add `SUPABASE_PROJECT_ID` to the job's secret environment variables so that automation can regenerate the types as part of checks.
+4. **Regenerate the TypeScript types** whenever the database schema changes:
+   ```bash
+   npm run types:supabase
+   ```
+5. **Commit the generated file** (`src/types/supabase.ts`) together with any schema changes to keep reviewers and CI in sync.
+
+## Development checklist
+
+- Run the appropriate linting or build commands for the area you changed.
+- Include tests or updates to Storybook stories when adding UI features.
+- Reference this document when updating CI pipelines so type generation stays automated.

--- a/README.md
+++ b/README.md
@@ -130,8 +130,9 @@ Before you begin, ensure you have the following installed:
 2. **Set up your database schema** (see `/database` folder for SQL scripts)
 3. **Configure Row Level Security** policies
 4. **Set up authentication** providers
-5. **Generate TypeScript types**:
+5. **Generate TypeScript types** (requires the Supabase CLI and the `SUPABASE_PROJECT_ID` environment variable):
    ```bash
+   export SUPABASE_PROJECT_ID=your_project_id
    npm run types:supabase
    ```
 

--- a/src/components/CostBreakdown.tsx
+++ b/src/components/CostBreakdown.tsx
@@ -5,6 +5,7 @@ import { Progress } from "@/components/ui/progress";
 import { Separator } from "@/components/ui/separator";
 import { InfoIcon, DollarSign, AlertCircle } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
+import type { TablesInsert } from "@/types/supabase";
 import {
   Tooltip,
   TooltipContent,
@@ -12,12 +13,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 
-interface CostItem {
-  name: string;
-  amount: number;
-  description?: string;
-  isPaid?: boolean;
-}
+type CostItem = TablesInsert<"cost_items">;
 
 interface CostBreakdownProps {
   loanAmount?: number;

--- a/src/components/DocumentManager.tsx
+++ b/src/components/DocumentManager.tsx
@@ -7,6 +7,7 @@ import { Badge } from "@/components/ui/badge";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Separator } from "@/components/ui/separator";
 import { Progress } from "@/components/ui/progress";
+import type { Tables } from "@/types/supabase";
 import {
   Check,
   Clock,
@@ -17,15 +18,7 @@ import {
   Eye,
 } from "lucide-react";
 
-interface Document {
-  id: string;
-  name: string;
-  stage: string;
-  status: "pending" | "approved" | "rejected";
-  uploadedBy: string;
-  uploadedAt: string;
-  version: number;
-}
+type Document = Tables<"documents">;
 
 const DocumentManager = () => {
   const [activeTab, setActiveTab] = useState("all");
@@ -79,7 +72,7 @@ const DocumentManager = () => {
 
   const stages = ["Pre-approval", "Appraisal", "Underwriting", "Closing"];
 
-  const getStatusIcon = (status: string) => {
+  const getStatusIcon = (status: Document["status"]) => {
     switch (status) {
       case "approved":
         return <Check className="h-4 w-4 text-green-500" />;
@@ -92,7 +85,7 @@ const DocumentManager = () => {
     }
   };
 
-  const getStatusBadge = (status: string) => {
+  const getStatusBadge = (status: Document["status"]) => {
     switch (status) {
       case "approved":
         return (

--- a/src/components/MessagingSystem.tsx
+++ b/src/components/MessagingSystem.tsx
@@ -22,31 +22,16 @@ import {
   SelectTrigger,
   SelectValue,
 } from "./ui/select";
+import type {
+  MessageSender,
+  Tables,
+} from "@/types/supabase";
 
-interface Message {
-  id: string;
-  sender: {
-    name: string;
-    avatar?: string;
-    role: string;
-  };
-  content: string;
-  timestamp: string;
-  attachments?: Array<{
-    name: string;
-    type: string;
-    url: string;
-  }>;
-  topic?: string;
-}
+type Message = Tables<"messages">;
 
 interface MessagingSystemProps {
   messages?: Message[];
-  currentUser?: {
-    name: string;
-    avatar?: string;
-    role: string;
-  };
+  currentUser?: MessageSender;
   topics?: string[];
 }
 
@@ -140,7 +125,7 @@ const MessagingSystem: React.FC<MessagingSystemProps> = ({
                 <div key={message.id} className="flex gap-3">
                   <Avatar className="h-8 w-8">
                     <AvatarImage
-                      src={message.sender.avatar}
+                      src={message.sender.avatar ?? undefined}
                       alt={message.sender.name}
                     />
                     <AvatarFallback>
@@ -212,7 +197,7 @@ const MessagingSystem: React.FC<MessagingSystemProps> = ({
 };
 
 // Default mock data
-const defaultCurrentUser = {
+const defaultCurrentUser: MessageSender = {
   name: "Juan Pérez",
   role: "Comprador",
   avatar: "https://api.dicebear.com/7.x/avataaars/svg?seed=Juan",
@@ -237,7 +222,9 @@ const defaultMessages: Message[] = [
     content:
       "Hola Juan, necesito que subas los documentos de ingresos actualizados para continuar con el proceso de aprobación.",
     timestamp: "Hoy, 10:30 AM",
+    attachments: null,
     topic: "Documentos",
+    participants: null,
   },
   {
     id: "2",
@@ -257,6 +244,7 @@ const defaultMessages: Message[] = [
         url: "#",
       },
     ],
+    participants: null,
   },
   {
     id: "3",
@@ -267,7 +255,9 @@ const defaultMessages: Message[] = [
     },
     content: "Ya subí los documentos solicitados. ¿Hay algo más que necesiten?",
     timestamp: "Ayer, 4:20 PM",
+    attachments: null,
     topic: "Documentos",
+    participants: null,
   },
   {
     id: "4",
@@ -279,7 +269,9 @@ const defaultMessages: Message[] = [
     content:
       "Hemos recibido tus documentos y están siendo revisados. Te notificaremos cuando estén aprobados.",
     timestamp: "Ayer, 5:15 PM",
+    attachments: null,
     topic: "Aprobación",
+    participants: null,
   },
   {
     id: "5",
@@ -291,7 +283,9 @@ const defaultMessages: Message[] = [
     content:
       "Recuerda que necesitamos los estados de cuenta bancarios de los últimos 3 meses.",
     timestamp: "Hoy, 9:00 AM",
+    attachments: null,
     topic: "Documentos",
+    participants: null,
   },
 ];
 

--- a/src/components/security/AuditLogger.tsx
+++ b/src/components/security/AuditLogger.tsx
@@ -6,6 +6,7 @@ import { Badge } from '@/components/ui/badge';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Separator } from '@/components/ui/separator';
+import type { Tables } from '@/types/supabase';
 import { 
   Activity, 
   Shield, 
@@ -23,22 +24,7 @@ import {
   RefreshCw
 } from 'lucide-react';
 
-interface AuditLog {
-  id: string;
-  timestamp: string;
-  userId: string;
-  userName: string;
-  userRole: string;
-  action: string;
-  resource: string;
-  resourceId?: string;
-  ipAddress: string;
-  userAgent: string;
-  status: 'success' | 'failed' | 'blocked';
-  riskLevel: 'low' | 'medium' | 'high' | 'critical';
-  details?: string;
-  location?: string;
-}
+type AuditLog = Tables<'audit_logs'>;
 
 const AuditLogger: React.FC = () => {
   const [auditLogs, setAuditLogs] = useState<AuditLog[]>([
@@ -55,6 +41,7 @@ const AuditLogger: React.FC = () => {
       userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
       status: 'success',
       riskLevel: 'low',
+      details: null,
       location: 'San Francisco, CA'
     },
     {
@@ -70,6 +57,7 @@ const AuditLogger: React.FC = () => {
       userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36',
       status: 'success',
       riskLevel: 'medium',
+      details: null,
       location: 'New York, NY'
     },
     {
@@ -80,6 +68,7 @@ const AuditLogger: React.FC = () => {
       userRole: 'unknown',
       action: 'login_attempt',
       resource: 'authentication',
+      resourceId: null,
       ipAddress: '198.51.100.42',
       userAgent: 'curl/7.68.0',
       status: 'blocked',
@@ -100,6 +89,7 @@ const AuditLogger: React.FC = () => {
       userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15',
       status: 'success',
       riskLevel: 'low',
+      details: null,
       location: 'Los Angeles, CA'
     },
     {
@@ -110,6 +100,7 @@ const AuditLogger: React.FC = () => {
       userRole: 'processor',
       action: 'bulk_export',
       resource: 'client_data',
+      resourceId: null,
       ipAddress: '192.168.1.110',
       userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
       status: 'success',

--- a/src/components/security/SecureDocumentManager.tsx
+++ b/src/components/security/SecureDocumentManager.tsx
@@ -7,6 +7,7 @@ import { Badge } from '@/components/ui/badge';
 import { Progress } from '@/components/ui/progress';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Separator } from '@/components/ui/separator';
+import type { Tables } from '@/types/supabase';
 import { 
   FileText, 
   Upload, 
@@ -21,20 +22,7 @@ import {
   Trash2
 } from 'lucide-react';
 
-interface SecureDocument {
-  id: string;
-  name: string;
-  type: string;
-  status: 'pending' | 'uploaded' | 'scanning' | 'approved' | 'rejected';
-  uploadDate?: string;
-  size?: string;
-  encryptionStatus: 'encrypted' | 'processing' | 'failed';
-  accessLevel: 'public' | 'team' | 'restricted';
-  lastAccessed?: string;
-  accessCount: number;
-  virusScanStatus: 'pending' | 'clean' | 'infected' | 'failed';
-  retentionDate?: string;
-}
+type SecureDocument = Tables<'secure_documents'>;
 
 const SecureDocumentManager: React.FC = () => {
   const [documents, setDocuments] = useState<SecureDocument[]>([
@@ -71,17 +59,21 @@ const SecureDocumentManager: React.FC = () => {
       name: 'Property Appraisal Report',
       type: 'Property',
       status: 'pending',
+      uploadDate: null,
+      size: null,
       encryptionStatus: 'processing',
       accessLevel: 'restricted',
+      lastAccessed: null,
       accessCount: 0,
-      virusScanStatus: 'pending'
+      virusScanStatus: 'pending',
+      retentionDate: null
     }
   ]);
 
   const [uploadProgress, setUploadProgress] = useState(0);
   const [isUploading, setIsUploading] = useState(false);
 
-  const getStatusIcon = (status: string) => {
+  const getStatusIcon = (status: SecureDocument['status']) => {
     switch (status) {
       case 'approved':
         return <CheckCircle className="h-4 w-4 text-green-500" />;
@@ -94,56 +86,58 @@ const SecureDocumentManager: React.FC = () => {
     }
   };
 
-  const getStatusBadge = (status: string) => {
-    const variants = {
+  const getStatusBadge = (status: SecureDocument['status']) => {
+    const variants: Record<SecureDocument['status'], string> = {
       approved: 'bg-green-100 text-green-800',
       scanning: 'bg-blue-100 text-blue-800',
       rejected: 'bg-red-100 text-red-800',
       pending: 'bg-gray-100 text-gray-800',
       uploaded: 'bg-yellow-100 text-yellow-800'
     };
-    
+
     return (
-      <Badge className={variants[status as keyof typeof variants]}>
+      <Badge className={variants[status]}>
         {status.charAt(0).toUpperCase() + status.slice(1)}
       </Badge>
     );
   };
 
-  const getEncryptionBadge = (status: string) => {
-    const variants = {
+  const getEncryptionBadge = (
+    status: SecureDocument['encryptionStatus']
+  ) => {
+    const variants: Record<SecureDocument['encryptionStatus'], string> = {
       encrypted: 'bg-green-100 text-green-800 border-green-200',
       processing: 'bg-yellow-100 text-yellow-800 border-yellow-200',
       failed: 'bg-red-100 text-red-800 border-red-200'
     };
-    
+
     return (
-      <Badge variant="outline" className={variants[status as keyof typeof variants]}>
+      <Badge variant="outline" className={variants[status]}>
         <Lock className="h-3 w-3 mr-1" />
         {status === 'encrypted' ? 'AES-256' : status}
       </Badge>
     );
   };
 
-  const getAccessLevelColor = (level: string) => {
-    const colors = {
+  const getAccessLevelColor = (level: SecureDocument['accessLevel']) => {
+    const colors: Record<SecureDocument['accessLevel'], string> = {
       public: 'text-green-600',
       team: 'text-blue-600',
       restricted: 'text-red-600'
     };
-    return colors[level as keyof typeof colors];
+    return colors[level];
   };
 
-  const getVirusScanBadge = (status: string) => {
-    const variants = {
+  const getVirusScanBadge = (status: SecureDocument['virusScanStatus']) => {
+    const variants: Record<SecureDocument['virusScanStatus'], string> = {
       clean: 'bg-green-100 text-green-800',
       pending: 'bg-gray-100 text-gray-800',
       infected: 'bg-red-100 text-red-800',
       failed: 'bg-yellow-100 text-yellow-800'
     };
-    
+
     return (
-      <Badge className={variants[status as keyof typeof variants]} variant="outline">
+      <Badge className={variants[status]} variant="outline">
         <Shield className="h-3 w-3 mr-1" />
         {status === 'clean' ? 'Virus Free' : status}
       </Badge>

--- a/src/pages/Documents.tsx
+++ b/src/pages/Documents.tsx
@@ -4,16 +4,9 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Progress } from '@/components/ui/progress';
 import { FileText, Upload, Download, Eye, Clock, CheckCircle, AlertCircle } from 'lucide-react';
+import type { Tables } from '@/types/supabase';
 
-interface Document {
-  id: string;
-  name: string;
-  type: string;
-  status: 'pending' | 'uploaded' | 'approved' | 'rejected';
-  uploadDate?: string;
-  size?: string;
-  required: boolean;
-}
+type Document = Tables<'document_requirements'>;
 
 const Documents: React.FC = () => {
   const documents: Document[] = [
@@ -40,6 +33,8 @@ const Documents: React.FC = () => {
       name: 'Property Appraisal',
       type: 'Property',
       status: 'pending',
+      uploadDate: null,
+      size: null,
       required: true
     },
     {
@@ -62,7 +57,7 @@ const Documents: React.FC = () => {
     }
   ];
 
-  const getStatusIcon = (status: string) => {
+  const getStatusIcon = (status: Document['status']) => {
     switch (status) {
       case 'approved':
         return <CheckCircle className="h-4 w-4 text-green-500" />;
@@ -75,16 +70,16 @@ const Documents: React.FC = () => {
     }
   };
 
-  const getStatusBadge = (status: string) => {
-    const variants = {
+  const getStatusBadge = (status: Document['status']) => {
+    const variants: Record<Document['status'], string> = {
       approved: 'bg-green-100 text-green-800',
       uploaded: 'bg-yellow-100 text-yellow-800',
       rejected: 'bg-red-100 text-red-800',
       pending: 'bg-gray-100 text-gray-800'
     };
-    
+
     return (
-      <Badge className={variants[status as keyof typeof variants]}>
+      <Badge className={variants[status]}>
         {status.charAt(0).toUpperCase() + status.slice(1)}
       </Badge>
     );

--- a/src/pages/Messages.tsx
+++ b/src/pages/Messages.tsx
@@ -8,24 +8,9 @@ import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { MessageCircle, Send, Paperclip, Filter, Search, Users } from 'lucide-react';
+import type { Tables } from '@/types/supabase';
 
-interface Message {
-  id: string;
-  sender: {
-    name: string;
-    avatar?: string;
-    role: string;
-  };
-  content: string;
-  timestamp: string;
-  attachments?: Array<{
-    name: string;
-    type: string;
-    url: string;
-  }>;
-  topic?: string;
-  participants?: string[];
-}
+type Message = Tables<'messages'>;
 
 const Messages: React.FC = () => {
   const [messageText, setMessageText] = useState('');
@@ -42,6 +27,7 @@ const Messages: React.FC = () => {
       },
       content: 'Hi! I\'ve reviewed your application and we need a few additional documents. Please upload your most recent pay stubs when you have a chance.',
       timestamp: '2024-01-15T10:30:00Z',
+      attachments: null,
       topic: 'Documentation',
       participants: ['You', 'Sarah Johnson']
     },
@@ -54,6 +40,7 @@ const Messages: React.FC = () => {
       },
       content: 'Great news! The seller has accepted your offer. We can now move forward with the inspection. I\'ll coordinate with the inspector and keep you updated.',
       timestamp: '2024-01-15T09:15:00Z',
+      attachments: null,
       topic: 'Property',
       participants: ['You', 'Mike Chen', 'Sarah Johnson']
     },
@@ -66,6 +53,7 @@ const Messages: React.FC = () => {
       },
       content: 'Thank you for the update! I\'ll upload the pay stubs today. When do you expect to have the final approval?',
       timestamp: '2024-01-15T11:45:00Z',
+      attachments: null,
       topic: 'Documentation',
       participants: ['You', 'Sarah Johnson']
     },
@@ -78,6 +66,7 @@ const Messages: React.FC = () => {
       },
       content: 'I\'ve processed your income verification documents. Everything looks good! We\'re on track for closing next week.',
       timestamp: '2024-01-14T16:20:00Z',
+      attachments: null,
       topic: 'Processing',
       participants: ['You', 'Lisa Rodriguez', 'Sarah Johnson']
     }
@@ -198,7 +187,7 @@ const Messages: React.FC = () => {
                       }`}
                     >
                       <Avatar className="h-8 w-8">
-                        <AvatarImage src={message.sender.avatar} />
+                        <AvatarImage src={message.sender.avatar ?? undefined} />
                         <AvatarFallback>
                           {message.sender.name.split(' ').map(n => n[0]).join('')}
                         </AvatarFallback>

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -8,29 +8,9 @@ import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
 import { User, Mail, Phone, MapPin, Building, Calendar, Edit, Save, X } from 'lucide-react';
+import type { Tables } from '@/types/supabase';
 
-interface UserProfile {
-  id: string;
-  firstName: string;
-  lastName: string;
-  email: string;
-  phone: string;
-  address: {
-    street: string;
-    city: string;
-    state: string;
-    zipCode: string;
-  };
-  employment: {
-    company: string;
-    position: string;
-    startDate: string;
-    annualIncome: string;
-  };
-  avatar?: string;
-  role: string;
-  joinDate: string;
-}
+type UserProfile = Tables<'profiles'>;
 
 const Profile: React.FC = () => {
   const [isEditing, setIsEditing] = useState(false);
@@ -108,7 +88,7 @@ const Profile: React.FC = () => {
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-4">
                 <Avatar className="h-20 w-20">
-                  <AvatarImage src={currentProfile.avatar} />
+                  <AvatarImage src={currentProfile.avatar ?? undefined} />
                   <AvatarFallback className="text-lg">
                     {currentProfile.firstName[0]}{currentProfile.lastName[0]}
                   </AvatarFallback>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -7,11 +7,11 @@ import { Switch } from '@/components/ui/switch';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Separator } from '@/components/ui/separator';
 import { Badge } from '@/components/ui/badge';
-import { 
-  Settings as SettingsIcon, 
-  Bell, 
-  Shield, 
-  Palette, 
+import {
+  Settings as SettingsIcon,
+  Bell,
+  Shield,
+  Palette,
   Globe, 
   Smartphone,
   Mail,
@@ -22,23 +22,11 @@ import {
   Trash2,
   AlertTriangle
 } from 'lucide-react';
+import type { TablesInsert } from '@/types/supabase';
 
-interface NotificationSettings {
-  email: boolean;
-  sms: boolean;
-  push: boolean;
-  documentUpdates: boolean;
-  messageAlerts: boolean;
-  milestoneReminders: boolean;
-  weeklyDigest: boolean;
-}
+type NotificationSettings = TablesInsert<'notification_settings'>;
 
-interface PrivacySettings {
-  profileVisibility: 'public' | 'team' | 'private';
-  dataSharing: boolean;
-  analyticsTracking: boolean;
-  marketingEmails: boolean;
-}
+type PrivacySettings = TablesInsert<'privacy_settings'>;
 
 const Settings: React.FC = () => {
   const [notifications, setNotifications] = useState<NotificationSettings>({

--- a/src/tempo-routes.ts
+++ b/src/tempo-routes.ts
@@ -1,0 +1,5 @@
+import type { RouteObject } from "react-router";
+
+const routes: RouteObject[] = [];
+
+export default routes;

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -1,0 +1,380 @@
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[];
+
+export type DocumentStatus = "pending" | "approved" | "rejected";
+export type SecureDocumentStatus =
+  | "pending"
+  | "uploaded"
+  | "scanning"
+  | "approved"
+  | "rejected";
+export type EncryptionStatus = "encrypted" | "processing" | "failed";
+export type AccessLevel = "public" | "team" | "restricted";
+export type VirusScanStatus = "pending" | "clean" | "infected" | "failed";
+export type AuditLogStatus = "success" | "failed" | "blocked";
+export type AuditLogRiskLevel = "low" | "medium" | "high" | "critical";
+
+export type MessageAttachment = {
+  name: string;
+  type: string;
+  url: string;
+};
+
+export type MessageSender = {
+  name: string;
+  avatar?: string | null;
+  role: string;
+};
+
+export type Address = {
+  street: string;
+  city: string;
+  state: string;
+  zipCode: string;
+};
+
+export type Employment = {
+  company: string;
+  position: string;
+  startDate: string;
+  annualIncome: string;
+};
+
+export type Database = {
+  public: {
+    Tables: {
+      audit_logs: {
+        Row: {
+          action: string;
+          details: string | null;
+          id: string;
+          ipAddress: string;
+          location: string | null;
+          resource: string;
+          resourceId: string | null;
+          riskLevel: AuditLogRiskLevel;
+          status: AuditLogStatus;
+          timestamp: string;
+          userAgent: string;
+          userId: string;
+          userName: string;
+          userRole: string;
+        };
+        Insert: {
+          action: string;
+          details?: string | null;
+          id?: string;
+          ipAddress: string;
+          location?: string | null;
+          resource: string;
+          resourceId?: string | null;
+          riskLevel: AuditLogRiskLevel;
+          status: AuditLogStatus;
+          timestamp: string;
+          userAgent: string;
+          userId: string;
+          userName: string;
+          userRole: string;
+        };
+        Update: {
+          action?: string;
+          details?: string | null;
+          id?: string;
+          ipAddress?: string;
+          location?: string | null;
+          resource?: string;
+          resourceId?: string | null;
+          riskLevel?: AuditLogRiskLevel;
+          status?: AuditLogStatus;
+          timestamp?: string;
+          userAgent?: string;
+          userId?: string;
+          userName?: string;
+          userRole?: string;
+        };
+        Relationships: [];
+      };
+      cost_items: {
+        Row: {
+          amount: number;
+          description: string | null;
+          id: string;
+          isPaid: boolean;
+          name: string;
+          type: "closing" | "tax" | "insurance" | "fee" | "other";
+        };
+        Insert: {
+          amount: number;
+          description?: string | null;
+          id?: string;
+          isPaid?: boolean;
+          name: string;
+          type?: "closing" | "tax" | "insurance" | "fee" | "other";
+        };
+        Update: {
+          amount?: number;
+          description?: string | null;
+          id?: string;
+          isPaid?: boolean;
+          name?: string;
+          type?: "closing" | "tax" | "insurance" | "fee" | "other";
+        };
+        Relationships: [];
+      };
+      documents: {
+        Row: {
+          id: string;
+          name: string;
+          stage: string;
+          status: DocumentStatus;
+          uploadedAt: string;
+          uploadedBy: string;
+          version: number;
+        };
+        Insert: {
+          id?: string;
+          name: string;
+          stage: string;
+          status?: DocumentStatus;
+          uploadedAt?: string;
+          uploadedBy: string;
+          version?: number;
+        };
+        Update: {
+          id?: string;
+          name?: string;
+          stage?: string;
+          status?: DocumentStatus;
+          uploadedAt?: string;
+          uploadedBy?: string;
+          version?: number;
+        };
+        Relationships: [];
+      };
+      document_requirements: {
+        Row: {
+          id: string;
+          name: string;
+          required: boolean;
+          size: string | null;
+          status: 'pending' | 'uploaded' | 'approved' | 'rejected';
+          type: string;
+          uploadDate: string | null;
+        };
+        Insert: {
+          id?: string;
+          name: string;
+          required?: boolean;
+          size?: string | null;
+          status?: 'pending' | 'uploaded' | 'approved' | 'rejected';
+          type: string;
+          uploadDate?: string | null;
+        };
+        Update: {
+          id?: string;
+          name?: string;
+          required?: boolean;
+          size?: string | null;
+          status?: 'pending' | 'uploaded' | 'approved' | 'rejected';
+          type?: string;
+          uploadDate?: string | null;
+        };
+        Relationships: [];
+      };
+      messages: {
+        Row: {
+          attachments: MessageAttachment[] | null;
+          content: string;
+          id: string;
+          participants: string[] | null;
+          sender: MessageSender;
+          timestamp: string;
+          topic: string | null;
+        };
+        Insert: {
+          attachments?: MessageAttachment[] | null;
+          content: string;
+          id?: string;
+          participants?: string[] | null;
+          sender: MessageSender;
+          timestamp: string;
+          topic?: string | null;
+        };
+        Update: {
+          attachments?: MessageAttachment[] | null;
+          content?: string;
+          id?: string;
+          participants?: string[] | null;
+          sender?: MessageSender;
+          timestamp?: string;
+          topic?: string | null;
+        };
+        Relationships: [];
+      };
+      notification_settings: {
+        Row: {
+          documentUpdates: boolean;
+          email: boolean;
+          id: string;
+          messageAlerts: boolean;
+          milestoneReminders: boolean;
+          push: boolean;
+          sms: boolean;
+          weeklyDigest: boolean;
+        };
+        Insert: {
+          documentUpdates?: boolean;
+          email?: boolean;
+          id?: string;
+          messageAlerts?: boolean;
+          milestoneReminders?: boolean;
+          push?: boolean;
+          sms?: boolean;
+          weeklyDigest?: boolean;
+        };
+        Update: {
+          documentUpdates?: boolean;
+          email?: boolean;
+          id?: string;
+          messageAlerts?: boolean;
+          milestoneReminders?: boolean;
+          push?: boolean;
+          sms?: boolean;
+          weeklyDigest?: boolean;
+        };
+        Relationships: [];
+      };
+      profiles: {
+        Row: {
+          address: Address;
+          avatar: string | null;
+          email: string;
+          employment: Employment;
+          firstName: string;
+          id: string;
+          joinDate: string;
+          lastName: string;
+          phone: string;
+          role: string;
+        };
+        Insert: {
+          address: Address;
+          avatar?: string | null;
+          email: string;
+          employment: Employment;
+          firstName: string;
+          id?: string;
+          joinDate?: string;
+          lastName: string;
+          phone: string;
+          role?: string;
+        };
+        Update: {
+          address?: Address;
+          avatar?: string | null;
+          email?: string;
+          employment?: Employment;
+          firstName?: string;
+          id?: string;
+          joinDate?: string;
+          lastName?: string;
+          phone?: string;
+          role?: string;
+        };
+        Relationships: [];
+      };
+      privacy_settings: {
+        Row: {
+          analyticsTracking: boolean;
+          dataSharing: boolean;
+          id: string;
+          marketingEmails: boolean;
+          profileVisibility: 'public' | 'team' | 'private';
+        };
+        Insert: {
+          analyticsTracking?: boolean;
+          dataSharing?: boolean;
+          id?: string;
+          marketingEmails?: boolean;
+          profileVisibility?: 'public' | 'team' | 'private';
+        };
+        Update: {
+          analyticsTracking?: boolean;
+          dataSharing?: boolean;
+          id?: string;
+          marketingEmails?: boolean;
+          profileVisibility?: 'public' | 'team' | 'private';
+        };
+        Relationships: [];
+      };
+      secure_documents: {
+        Row: {
+          accessCount: number;
+          accessLevel: AccessLevel;
+          encryptionStatus: EncryptionStatus;
+          id: string;
+          lastAccessed: string | null;
+          name: string;
+          retentionDate: string | null;
+          size: string | null;
+          status: SecureDocumentStatus;
+          type: string;
+          uploadDate: string | null;
+          virusScanStatus: VirusScanStatus;
+        };
+        Insert: {
+          accessCount?: number;
+          accessLevel: AccessLevel;
+          encryptionStatus: EncryptionStatus;
+          id?: string;
+          lastAccessed?: string | null;
+          name: string;
+          retentionDate?: string | null;
+          size?: string | null;
+          status?: SecureDocumentStatus;
+          type: string;
+          uploadDate?: string | null;
+          virusScanStatus?: VirusScanStatus;
+        };
+        Update: {
+          accessCount?: number;
+          accessLevel?: AccessLevel;
+          encryptionStatus?: EncryptionStatus;
+          id?: string;
+          lastAccessed?: string | null;
+          name?: string;
+          retentionDate?: string | null;
+          size?: string | null;
+          status?: SecureDocumentStatus;
+          type?: string;
+          uploadDate?: string | null;
+          virusScanStatus?: VirusScanStatus;
+        };
+        Relationships: [];
+      };
+    };
+    Views: {};
+    Functions: {};
+    Enums: {};
+    CompositeTypes: {};
+  };
+};
+
+export type Tables<TableName extends keyof Database["public"]["Tables"]> =
+  Database["public"]["Tables"][TableName]["Row"];
+
+export type TablesInsert<
+  TableName extends keyof Database["public"]["Tables"]
+> = Database["public"]["Tables"][TableName]["Insert"];
+
+export type TablesUpdate<
+  TableName extends keyof Database["public"]["Tables"]
+> = Database["public"]["Tables"][TableName]["Update"];
+
+export type Enums<EnumName extends keyof Database["public"]["Enums"]> =
+  Database["public"]["Enums"][EnumName];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,8 @@
 
     "strict": false,
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "tempo-routes": ["./src/tempo-routes"]
     }
   },
   "include": ["src"],


### PR DESCRIPTION
## Summary
- add Supabase database typings with helper aliases for common tables and enums
- refactor document, messaging, profile, and settings views to consume the generated Supabase types instead of ad-hoc interfaces
- document the Supabase type regeneration workflow and add a local tempo routes stub plus TypeScript path mapping for builds

## Testing
- npm run build -- --mode development

------
https://chatgpt.com/codex/tasks/task_e_68e17ee760348328816eb9f98cd57878