### PR TITLE
Add Supabase messaging schema and real-time client integration

### DIFF
--- a/src/components/MessagingSystem.tsx
+++ b/src/components/MessagingSystem.tsx
@@ -1,8 +1,7 @@
-import React, { useState } from "react";
+import React, { useMemo, useRef, useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
-import { Input } from "./ui/input";
 import { Button } from "./ui/button";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "./ui/tabs";
+import { Tabs, TabsList, TabsTrigger } from "./ui/tabs";
 import { Avatar, AvatarFallback, AvatarImage } from "./ui/avatar";
 import { ScrollArea } from "./ui/scroll-area";
 import { Textarea } from "./ui/textarea";
@@ -13,6 +12,8 @@ import {
   UserIcon,
   Users2Icon,
   FilterIcon,
+  Loader2,
+  AlertCircle,
 } from "lucide-react";
 import { Separator } from "./ui/separator";
 import {
@@ -22,81 +23,145 @@ import {
   SelectTrigger,
   SelectValue,
 } from "./ui/select";
-
-interface Message {
-  id: string;
-  sender: {
-    name: string;
-    avatar?: string;
-    role: string;
-  };
-  content: string;
-  timestamp: string;
-  attachments?: Array<{
-    name: string;
-    type: string;
-    url: string;
-  }>;
-  topic?: string;
-}
+import { Alert, AlertDescription } from "./ui/alert";
+import { useMessaging } from "@/hooks/useMessaging";
+import type { MessagingUser } from "@/hooks/useMessaging";
 
 interface MessagingSystemProps {
-  messages?: Message[];
-  currentUser?: {
-    name: string;
-    avatar?: string;
-    role: string;
-  };
-  topics?: string[];
+  currentUser: MessagingUser;
 }
 
-const MessagingSystem: React.FC<MessagingSystemProps> = ({
-  messages = defaultMessages,
-  currentUser = defaultCurrentUser,
-  topics = defaultTopics,
-}) => {
+const MessagingSystem: React.FC<MessagingSystemProps> = ({ currentUser }) => {
   const [messageText, setMessageText] = useState("");
   const [activeTab, setActiveTab] = useState("all");
-  const [selectedTopic, setSelectedTopic] = useState<string | undefined>(
-    undefined,
+  const [selectedTopic, setSelectedTopic] = useState("all");
+  const [pendingAttachments, setPendingAttachments] = useState<File[]>([]);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  const {
+    conversations,
+    messages,
+    selectedConversationId,
+    selectConversation,
+    loadingConversations,
+    loadingMessages,
+    sending,
+    error,
+    clearError,
+    sendMessage,
+  } = useMessaging({ currentUser });
+
+  const currentConversation = useMemo(
+    () =>
+      conversations.find(
+        (conversation) => conversation.id === selectedConversationId,
+      ) ?? null,
+    [conversations, selectedConversationId],
   );
 
-  const filteredMessages = messages
-    .filter((message) => {
-      if (activeTab === "all") return true;
-      if (activeTab === "direct" && message.sender.role !== currentUser.role)
+  const topics = useMemo(() => {
+    const topicSet = new Set<string>();
+    messages.forEach((message) => {
+      if (message.topic) {
+        topicSet.add(message.topic);
+      }
+    });
+    return Array.from(topicSet);
+  }, [messages]);
+
+  const filteredMessages = useMemo(() => {
+    return messages
+      .filter((message) => {
+        if (activeTab === "all") return true;
+        if (activeTab === "direct") return !message.sender.isCurrentUser;
+        if (activeTab === "topics") return Boolean(message.topic);
         return true;
-      if (activeTab === "topics" && message.topic) return true;
-      return false;
-    })
-    .filter((message) => {
-      if (!selectedTopic || selectedTopic === "all") return true;
-      return message.topic === selectedTopic;
+      })
+      .filter((message) => {
+        if (selectedTopic === "all") return true;
+        return message.topic === selectedTopic;
+      });
+  }, [messages, activeTab, selectedTopic]);
+
+  const handleSendMessage = async () => {
+    if (!messageText.trim() || !selectedConversationId) return;
+
+    await sendMessage({
+      conversationId: selectedConversationId,
+      content: messageText,
+      topic: selectedTopic !== "all" ? selectedTopic : undefined,
+      attachments: pendingAttachments,
     });
 
-  const handleSendMessage = () => {
-    if (messageText.trim()) {
-      // In a real app, this would send the message to a backend
-      console.log("Sending message:", messageText);
-      setMessageText("");
+    setMessageText("");
+    setPendingAttachments([]);
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (event.key === "Enter" && !event.shiftKey) {
+      event.preventDefault();
+      void handleSendMessage();
     }
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === "Enter" && !e.shiftKey) {
-      e.preventDefault();
-      handleSendMessage();
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(event.target.files ?? []);
+    if (files.length) {
+      setPendingAttachments((current) => [...current, ...files]);
     }
+    event.target.value = "";
+  };
+
+  const removeAttachment = (index: number) => {
+    setPendingAttachments((current) => current.filter((_, idx) => idx !== index));
   };
 
   return (
     <Card className="w-full bg-white shadow-md">
-      <CardHeader className="pb-3">
-        <div className="flex justify-between items-center">
-          <CardTitle className="text-xl font-bold">Mensajes</CardTitle>
-          <div className="flex items-center gap-2">
-            <Select value={selectedTopic} onValueChange={setSelectedTopic}>
-              <SelectTrigger className="w-[180px]">
+      <CardHeader className="pb-4 space-y-4">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <CardTitle className="text-xl font-bold">Mensajes</CardTitle>
+            <p className="text-sm text-muted-foreground">
+              {loadingConversations
+                ? "Cargando conversaciones..."
+                : `${conversations.length} conversaciones`}
+            </p>
+          </div>
+          <div className="flex flex-col sm:flex-row gap-2 sm:items-center">
+            <Select
+              value={selectedConversationId ?? ""}
+              onValueChange={(value) => selectConversation(value)}
+              disabled={loadingConversations || conversations.length === 0}
+            >
+              <SelectTrigger className="w-full sm:w-[220px]">
+                <SelectValue placeholder="Selecciona una conversación" />
+              </SelectTrigger>
+              <SelectContent>
+                {conversations.map((conversation) => {
+                  const participantNames = conversation.participants
+                    .filter((participant) => !participant.isCurrentUser)
+                    .map((participant) => participant.displayName)
+                    .join(", ")
+
+                  const label =
+                    conversation.title ??
+                    (participantNames ? participantNames : "Conversación")
+
+                  return (
+                    <SelectItem key={conversation.id} value={conversation.id}>
+                      {label}
+                    </SelectItem>
+                  )
+                })}
+              </SelectContent>
+            </Select>
+            <Select
+              value={selectedTopic}
+              onValueChange={setSelectedTopic}
+              disabled={topics.length === 0}
+            >
+              <SelectTrigger className="w-full sm:w-[180px]">
                 <SelectValue placeholder="Filtrar por tema" />
               </SelectTrigger>
               <SelectContent>
@@ -114,95 +179,209 @@ const MessagingSystem: React.FC<MessagingSystemProps> = ({
           </div>
         </div>
         <Tabs
-          defaultValue="all"
-          className="w-full"
           value={activeTab}
           onValueChange={setActiveTab}
+          className="w-full"
         >
           <TabsList className="grid w-full grid-cols-3">
             <TabsTrigger value="all" className="flex items-center gap-2">
               <Users2Icon className="h-4 w-4" /> Todos
             </TabsTrigger>
             <TabsTrigger value="direct" className="flex items-center gap-2">
-              <UserIcon className="h-4 w-4" /> Directos
+              <UserIcon className="h-4 w-4" /> Equipo
             </TabsTrigger>
             <TabsTrigger value="topics" className="flex items-center gap-2">
               # Temas
             </TabsTrigger>
           </TabsList>
         </Tabs>
+        {error && (
+          <Alert variant="destructive" className="flex items-start gap-3">
+            <AlertCircle className="h-4 w-4" />
+            <AlertDescription className="flex-1">
+              {error}
+              <Button
+                variant="link"
+                className="h-auto p-0 ml-2"
+                onClick={clearError}
+              >
+                Entendido
+              </Button>
+            </AlertDescription>
+          </Alert>
+        )}
       </CardHeader>
-      <CardContent>
-        <ScrollArea className="h-[350px] pr-4">
+      <CardContent className="space-y-4">
+        <div className="flex items-center justify-between">
+          <div className="text-sm text-muted-foreground">
+            {currentConversation
+              ? (() => {
+                  const participantNames = currentConversation.participants
+                    .filter((participant) => !participant.isCurrentUser)
+                    .map((participant) => participant.displayName)
+                    .join(", ")
+                  return participantNames || "Conversación"
+                })()
+              : "Selecciona una conversación"}
+          </div>
+          {sending && (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" /> Enviando...
+            </div>
+          )}
+        </div>
+        <ScrollArea className="h-[320px] pr-4">
           <div className="flex flex-col gap-4">
-            {filteredMessages.length > 0 ? (
+            {loadingMessages ? (
+              <div className="flex justify-center py-12 text-muted-foreground">
+                <Loader2 className="h-6 w-6 animate-spin" />
+              </div>
+            ) : filteredMessages.length > 0 ? (
               filteredMessages.map((message) => (
-                <div key={message.id} className="flex gap-3">
+                <div
+                  key={message.id}
+                  className="flex gap-3"
+                >
                   <Avatar className="h-8 w-8">
-                    <AvatarImage
-                      src={message.sender.avatar}
-                      alt={message.sender.name}
-                    />
+                    <AvatarImage src={message.sender.avatarUrl ?? undefined} />
                     <AvatarFallback>
-                      {message.sender.name.charAt(0)}
+                      {message.sender.displayName.charAt(0)}
                     </AvatarFallback>
                   </Avatar>
                   <div className="flex flex-col flex-1">
                     <div className="flex items-center gap-2">
-                      <span className="font-medium">{message.sender.name}</span>
+                      <span className="font-medium">
+                        {message.sender.displayName}
+                      </span>
                       <Badge variant="outline" className="text-xs">
                         {message.sender.role}
                       </Badge>
                       <span className="text-xs text-muted-foreground ml-auto">
-                        {message.timestamp}
+                        {new Date(message.createdAt).toLocaleString()}
                       </span>
                     </div>
-                    <p className="text-sm mt-1">{message.content}</p>
+                    <p className="text-sm mt-1 whitespace-pre-line">
+                      {message.content}
+                    </p>
                     {message.topic && (
-                      <Badge variant="secondary" className="mt-1 w-fit">
+                      <Badge variant="secondary" className="mt-2 w-fit">
                         # {message.topic}
                       </Badge>
                     )}
-                    {message.attachments && message.attachments.length > 0 && (
-                      <div className="flex gap-2 mt-2">
-                        {message.attachments.map((attachment, index) => (
+                    {message.attachments.length > 0 && (
+                      <div className="flex flex-wrap gap-2 mt-2">
+                        {message.attachments.map((attachment) => (
                           <div
-                            key={index}
-                            className="flex items-center gap-1 bg-muted px-2 py-1 rounded text-xs"
+                            key={attachment.id}
+                            className="flex items-center gap-2 bg-muted px-2 py-1 rounded text-xs"
                           >
                             <PaperclipIcon className="h-3 w-3" />
-                            <span>{attachment.name}</span>
+                            <span className="max-w-[160px] truncate">
+                              {attachment.name}
+                            </span>
+                            {attachment.status !== "sent" && (
+                              <Badge
+                                variant={
+                                  attachment.status === "error"
+                                    ? "destructive"
+                                    : "outline"
+                                }
+                              >
+                                {attachment.status === "pending"
+                                  ? "Subiendo..."
+                                  : "Error"}
+                              </Badge>
+                            )}
                           </div>
                         ))}
                       </div>
+                    )}
+                    {message.status !== "sent" && (
+                      <Badge
+                        variant={
+                          message.status === "error"
+                            ? "destructive"
+                            : "outline"
+                        }
+                        className="mt-2 w-fit"
+                      >
+                        {message.status === "pending"
+                          ? "Enviando..."
+                          : "No se pudo entregar"}
+                      </Badge>
                     )}
                   </div>
                 </div>
               ))
             ) : (
               <div className="text-center py-8 text-muted-foreground">
-                No hay mensajes para mostrar en esta categoría.
+                No hay mensajes para mostrar.
               </div>
             )}
           </div>
         </ScrollArea>
-        <Separator className="my-4" />
-        <div className="flex flex-col gap-2">
+        <Separator />
+        <div className="flex flex-col gap-3">
           <Textarea
             placeholder="Escribe tu mensaje aquí..."
             value={messageText}
-            onChange={(e) => setMessageText(e.target.value)}
+            onChange={(event) => setMessageText(event.target.value)}
             onKeyDown={handleKeyDown}
             className="min-h-[80px] resize-none"
+            disabled={!selectedConversationId}
           />
-          <div className="flex justify-between">
-            <Button variant="outline" size="sm">
-              <PaperclipIcon className="h-4 w-4 mr-2" />
-              Adjuntar
-            </Button>
-            <Button onClick={handleSendMessage} disabled={!messageText.trim()}>
-              <SendIcon className="h-4 w-4 mr-2" />
-              Enviar
+          {pendingAttachments.length > 0 && (
+            <div className="flex flex-wrap gap-2">
+              {pendingAttachments.map((file, index) => (
+                <div
+                  key={`${file.name}-${index}`}
+                  className="flex items-center gap-2 rounded border px-2 py-1 text-xs"
+                >
+                  <PaperclipIcon className="h-3 w-3" />
+                  <span className="max-w-[160px] truncate">{file.name}</span>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-5 px-1"
+                    onClick={() => removeAttachment(index)}
+                  >
+                    ×
+                  </Button>
+                </div>
+              ))}
+            </div>
+          )}
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+            <div className="flex items-center gap-2">
+              <input
+                ref={fileInputRef}
+                type="file"
+                multiple
+                hidden
+                onChange={handleFileChange}
+              />
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => fileInputRef.current?.click()}
+                disabled={!selectedConversationId}
+              >
+                <PaperclipIcon className="h-4 w-4 mr-2" />
+                Adjuntar
+              </Button>
+            </div>
+            <Button
+              onClick={() => void handleSendMessage()}
+              disabled={
+                !messageText.trim() || !selectedConversationId || sending
+              }
+            >
+              {sending ? (
+                <Loader2 className="h-4 w-4 animate-spin mr-2" />
+              ) : (
+                <SendIcon className="h-4 w-4 mr-2" />
+              )}
+              {sending ? "Enviando" : "Enviar"}
             </Button>
           </div>
         </div>
@@ -210,89 +389,5 @@ const MessagingSystem: React.FC<MessagingSystemProps> = ({
     </Card>
   );
 };
-
-// Default mock data
-const defaultCurrentUser = {
-  name: "Juan Pérez",
-  role: "Comprador",
-  avatar: "https://api.dicebear.com/7.x/avataaars/svg?seed=Juan",
-};
-
-const defaultTopics = [
-  "Documentos",
-  "Tasación",
-  "Aprobación",
-  "Cierre",
-  "General",
-];
-
-const defaultMessages: Message[] = [
-  {
-    id: "1",
-    sender: {
-      name: "María López",
-      role: "Agente",
-      avatar: "https://api.dicebear.com/7.x/avataaars/svg?seed=Maria",
-    },
-    content:
-      "Hola Juan, necesito que subas los documentos de ingresos actualizados para continuar con el proceso de aprobación.",
-    timestamp: "Hoy, 10:30 AM",
-    topic: "Documentos",
-  },
-  {
-    id: "2",
-    sender: {
-      name: "Carlos Rodríguez",
-      role: "Prestamista",
-      avatar: "https://api.dicebear.com/7.x/avataaars/svg?seed=Carlos",
-    },
-    content:
-      "La tasación está programada para el próximo martes a las 2:00 PM. Por favor asegúrate de estar presente.",
-    timestamp: "Ayer, 3:45 PM",
-    topic: "Tasación",
-    attachments: [
-      {
-        name: "Detalles_Tasacion.pdf",
-        type: "pdf",
-        url: "#",
-      },
-    ],
-  },
-  {
-    id: "3",
-    sender: {
-      name: "Juan Pérez",
-      role: "Comprador",
-      avatar: "https://api.dicebear.com/7.x/avataaars/svg?seed=Juan",
-    },
-    content: "Ya subí los documentos solicitados. ¿Hay algo más que necesiten?",
-    timestamp: "Ayer, 4:20 PM",
-    topic: "Documentos",
-  },
-  {
-    id: "4",
-    sender: {
-      name: "Ana Martínez",
-      role: "Procesador",
-      avatar: "https://api.dicebear.com/7.x/avataaars/svg?seed=Ana",
-    },
-    content:
-      "Hemos recibido tus documentos y están siendo revisados. Te notificaremos cuando estén aprobados.",
-    timestamp: "Ayer, 5:15 PM",
-    topic: "Aprobación",
-  },
-  {
-    id: "5",
-    sender: {
-      name: "María López",
-      role: "Agente",
-      avatar: "https://api.dicebear.com/7.x/avataaars/svg?seed=Maria",
-    },
-    content:
-      "Recuerda que necesitamos los estados de cuenta bancarios de los últimos 3 meses.",
-    timestamp: "Hoy, 9:00 AM",
-    topic: "Documentos",
-  },
-];
 
 export default MessagingSystem;

--- a/src/components/home.tsx
+++ b/src/components/home.tsx
@@ -16,14 +16,23 @@ import MortgageTimeline from "./MortgageTimeline";
 import DocumentManager from "./DocumentManager";
 import MessagingSystem from "./MessagingSystem";
 import CostBreakdown from "./CostBreakdown";
+import type { MessagingUser } from "@/hooks/useMessaging";
 
 const HomePage = () => {
   // Mock user data - in a real app this would come from authentication
   const user = {
+    id: "00000000-0000-0000-0000-000000000002",
     name: "Carlos Rodriguez",
     role: "homebuyer", // Could be: 'homebuyer', 'agent', 'lender', 'processor'
     avatar: "https://api.dicebear.com/7.x/avataaars/svg?seed=Carlos",
     notifications: 3,
+  };
+
+  const messagingUser: MessagingUser = {
+    id: user.id,
+    name: user.name,
+    role: user.role,
+    avatarUrl: user.avatar,
   };
 
   // Mock loan data
@@ -191,7 +200,7 @@ const HomePage = () => {
                     <CardTitle>Messaging System</CardTitle>
                   </CardHeader>
                   <CardContent>
-                    <MessagingSystem />
+                    <MessagingSystem currentUser={messagingUser} />
                   </CardContent>
                 </Card>
               </TabsContent>

--- a/src/hooks/useMessaging.ts
+++ b/src/hooks/useMessaging.ts
@@ -1,0 +1,727 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+
+import { supabase } from "@/lib/supabaseClient"
+import type { Database } from "@/types/supabase"
+import type { RealtimePostgresInsertPayload } from "@supabase/supabase-js"
+
+export interface MessagingUser {
+  id: string
+  name: string
+  role: string
+  avatarUrl?: string | null
+}
+
+export interface ParticipantProfile {
+  id: string
+  displayName: string
+  avatarUrl?: string | null
+  role: string
+  isCurrentUser: boolean
+}
+
+export interface MessageAttachment {
+  id: string
+  messageId: string
+  name: string
+  url: string | null
+  contentType: string | null
+  size: number | null
+  createdAt: string
+  status: "pending" | "sent" | "error"
+}
+
+export interface ConversationMessage {
+  id: string
+  conversationId: string
+  content: string
+  topic: string | null
+  createdAt: string
+  sender: ParticipantProfile
+  attachments: MessageAttachment[]
+  status: "pending" | "sent" | "error"
+  optimisticKey?: string
+}
+
+export interface ConversationPreview {
+  id: string
+  title: string | null
+  updatedAt: string
+  participants: ParticipantProfile[]
+  lastMessage?: ConversationMessage
+}
+
+type Tables = Database["public"]["Tables"]
+type MessageRow = Tables["messages"]["Row"]
+type AttachmentRow = Tables["attachments"]["Row"]
+type ParticipantRow = Tables["participants"]["Row"]
+type ConversationRow = Tables["conversations"]["Row"]
+
+type MessageWithAttachments = MessageRow & { attachments?: AttachmentRow[] | null }
+type ConversationSelectRow = ConversationRow & {
+  participants: ParticipantRow[]
+  latest_message?: MessageWithAttachments[] | null
+}
+
+export interface UseMessagingOptions {
+  currentUser: MessagingUser | null
+  initialConversationId?: string | null
+}
+
+export interface SendMessageOptions {
+  conversationId: string
+  content: string
+  topic?: string | null
+  attachments?: File[]
+}
+
+export interface UseMessagingResult {
+  conversations: ConversationPreview[]
+  messages: ConversationMessage[]
+  selectedConversationId: string | null
+  loadingConversations: boolean
+  loadingMessages: boolean
+  sending: boolean
+  error: string | null
+  selectConversation: (conversationId: string) => void
+  clearError: () => void
+  sendMessage: (options: SendMessageOptions) => Promise<void>
+  refresh: () => Promise<void>
+}
+
+const ATTACHMENT_BUCKET = "message-attachments"
+
+const formatParticipant = (
+  row: ParticipantRow,
+  currentUserId: string | null,
+): ParticipantProfile => ({
+  id: row.user_id,
+  displayName: row.display_name,
+  avatarUrl: row.avatar_url ?? undefined,
+  role: row.role,
+  isCurrentUser: currentUserId === row.user_id,
+})
+
+const formatAttachment = (row: AttachmentRow): MessageAttachment => ({
+  id: row.id,
+  messageId: row.message_id,
+  name: row.name,
+  url: row.url,
+  contentType: row.content_type,
+  size: row.size,
+  createdAt: row.created_at,
+  status: "sent",
+})
+
+const formatMessage = (
+  row: MessageWithAttachments,
+  participants: ParticipantProfile[],
+  fallbackSender: ParticipantProfile,
+  status: ConversationMessage["status"] = "sent",
+  attachmentOverrides?: MessageAttachment[],
+): ConversationMessage => {
+  const sender =
+    participants.find((participant) => participant.id === row.sender_id) ??
+    fallbackSender
+
+  return {
+    id: row.id,
+    conversationId: row.conversation_id,
+    content: row.content,
+    topic: row.topic,
+    createdAt: row.created_at,
+    sender,
+    attachments:
+      attachmentOverrides ?? (row.attachments ?? []).map(formatAttachment),
+    status,
+  }
+}
+
+const mapConversation = (
+  row: ConversationSelectRow,
+  currentUserId: string | null,
+): ConversationPreview => {
+  const participants = (row.participants ?? []).map((participant) =>
+    formatParticipant(participant, currentUserId),
+  )
+
+  const fallbackSender =
+    participants.find((participant) => participant.isCurrentUser) ??
+    ({
+      id: currentUserId ?? "",
+      displayName: "You",
+      avatarUrl: undefined,
+      role: "member",
+      isCurrentUser: true,
+    } satisfies ParticipantProfile)
+
+  const lastMessageRow = row.latest_message?.[0]
+  return {
+    id: row.id,
+    title: row.title,
+    updatedAt: row.updated_at,
+    participants,
+    lastMessage: lastMessageRow
+      ? formatMessage(lastMessageRow, participants, fallbackSender)
+      : undefined,
+  }
+}
+
+const getPublicUrl = (path: string) => {
+  const { data } = supabase.storage.from(ATTACHMENT_BUCKET).getPublicUrl(path)
+  return data.publicUrl
+}
+
+export const useMessaging = ({
+  currentUser,
+  initialConversationId = null,
+}: UseMessagingOptions): UseMessagingResult => {
+  const [conversations, setConversations] = useState<ConversationPreview[]>([])
+  const [messagesByConversation, setMessagesByConversation] = useState<
+    Record<string, ConversationMessage[]>
+  >({})
+  const [selectedConversationId, setSelectedConversationId] = useState<
+    string | null
+  >(initialConversationId)
+  const [loadingConversations, setLoadingConversations] = useState(false)
+  const [loadingMessages, setLoadingMessages] = useState(false)
+  const [sending, setSending] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const conversationsRef = useRef<ConversationPreview[]>([])
+  const messagesRef = useRef<Record<string, ConversationMessage[]>>({})
+
+  useEffect(() => {
+    conversationsRef.current = conversations
+  }, [conversations])
+
+  useEffect(() => {
+    messagesRef.current = messagesByConversation
+  }, [messagesByConversation])
+
+  const getParticipants = useCallback(
+    (conversationId: string): ParticipantProfile[] => {
+      return (
+        conversationsRef.current.find(
+          (conversation) => conversation.id === conversationId,
+        )?.participants ?? []
+      )
+    },
+    [],
+  )
+
+  const fetchConversations = useCallback(async () => {
+    if (!currentUser?.id) return
+
+    setLoadingConversations(true)
+    const { data, error } = await supabase
+      .from("conversations")
+      .select(
+        `
+        id,
+        title,
+        updated_at,
+        participants:participants!inner (
+          user_id,
+          role,
+          display_name,
+          avatar_url
+        ),
+        latest_message:messages(order=created_at.desc, limit=1) (
+          id,
+          conversation_id,
+          content,
+          created_at,
+          sender_id,
+          sender_role,
+          topic,
+          attachments (
+            id,
+            message_id,
+            name,
+            url,
+            content_type,
+            storage_path,
+            size,
+            created_at
+          )
+        )
+      `,
+      )
+      .eq("participants.user_id", currentUser.id)
+      .order("updated_at", { ascending: false })
+
+    if (error) {
+      setError(error.message)
+      setLoadingConversations(false)
+      return
+    }
+
+    const formatted = (data as unknown as ConversationSelectRow[]).map((row) =>
+      mapConversation(row, currentUser.id),
+    )
+    setConversations(formatted)
+    setLoadingConversations(false)
+
+    if (!selectedConversationId && formatted.length > 0) {
+      setSelectedConversationId(formatted[0].id)
+    }
+  }, [currentUser?.id, selectedConversationId])
+
+  const fetchMessages = useCallback(
+    async (conversationId: string) => {
+      if (!currentUser?.id) return
+
+      setLoadingMessages(true)
+      const { data, error } = await supabase
+        .from("messages")
+        .select(
+          `
+          id,
+          conversation_id,
+          content,
+          created_at,
+          sender_id,
+          sender_role,
+          topic,
+          attachments (
+            id,
+            message_id,
+            name,
+            url,
+            content_type,
+            storage_path,
+            size,
+            created_at
+          )
+        `,
+        )
+        .eq("conversation_id", conversationId)
+        .order("created_at", { ascending: true })
+
+      if (error) {
+        setError(error.message)
+        setLoadingMessages(false)
+        return
+      }
+
+      const participants = getParticipants(conversationId)
+      const fallbackSender =
+        participants.find((participant) => participant.isCurrentUser) ??
+        ({
+          id: currentUser.id,
+          displayName: currentUser.name,
+          avatarUrl: currentUser.avatarUrl,
+          role: currentUser.role,
+          isCurrentUser: true,
+        } satisfies ParticipantProfile)
+
+      const formatted = (data as MessageWithAttachments[]).map((row) =>
+        formatMessage(row, participants, fallbackSender),
+      )
+
+      setMessagesByConversation((previous) => ({
+        ...previous,
+        [conversationId]: formatted,
+      }))
+      setLoadingMessages(false)
+    },
+    [currentUser, getParticipants],
+  )
+
+  const refresh = useCallback(async () => {
+    await fetchConversations()
+    if (selectedConversationId) {
+      await fetchMessages(selectedConversationId)
+    }
+  }, [fetchConversations, fetchMessages, selectedConversationId])
+
+  useEffect(() => {
+    fetchConversations()
+  }, [fetchConversations])
+
+  useEffect(() => {
+    if (selectedConversationId) {
+      fetchMessages(selectedConversationId)
+    }
+  }, [fetchMessages, selectedConversationId])
+
+  useEffect(() => {
+    if (!currentUser?.id) return
+
+    const channel = supabase
+      .channel(`messaging-${currentUser.id}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "INSERT",
+          schema: "public",
+          table: "messages",
+        },
+        async (payload: RealtimePostgresInsertPayload<MessageRow>) => {
+          const messageRow = payload.new
+          const participants = getParticipants(messageRow.conversation_id)
+          const fallbackSender =
+            participants.find((participant) => participant.isCurrentUser) ??
+            ({
+              id: currentUser.id,
+              displayName: currentUser.name,
+              avatarUrl: currentUser.avatarUrl,
+              role: currentUser.role,
+              isCurrentUser: true,
+            } satisfies ParticipantProfile)
+
+          const { data: attachmentRows } = await supabase
+            .from("attachments")
+            .select(
+              `
+              id,
+              message_id,
+              name,
+              url,
+              content_type,
+              storage_path,
+              size,
+              created_at
+            `,
+            )
+            .eq("message_id", messageRow.id)
+
+          const messageWithAttachments: MessageWithAttachments = {
+            ...messageRow,
+            attachments: attachmentRows ?? [],
+          }
+
+          const formattedMessage = formatMessage(
+            messageWithAttachments,
+            participants,
+            fallbackSender,
+          )
+
+          setMessagesByConversation((previous) => {
+            const existing = previous[messageRow.conversation_id] ?? []
+            if (existing.some((message) => message.id === formattedMessage.id)) {
+              return previous
+            }
+
+            return {
+              ...previous,
+              [messageRow.conversation_id]: [
+                ...existing,
+                { ...formattedMessage, status: "sent" },
+              ],
+            }
+          })
+
+          setConversations((previous) => {
+            const index = previous.findIndex(
+              (conversation) => conversation.id === messageRow.conversation_id,
+            )
+            if (index === -1) return previous
+
+            const updatedConversation: ConversationPreview = {
+              ...previous[index],
+              updatedAt: messageRow.created_at,
+              lastMessage: { ...formattedMessage, status: "sent" },
+            }
+
+            const reordered = [
+              updatedConversation,
+              ...previous.filter(
+                (conversation) =>
+                  conversation.id !== messageRow.conversation_id,
+              ),
+            ]
+
+            return reordered
+          })
+        },
+      )
+      .on(
+        "postgres_changes",
+        {
+          event: "INSERT",
+          schema: "public",
+          table: "attachments",
+        },
+        (payload: RealtimePostgresInsertPayload<AttachmentRow>) => {
+          const attachment = formatAttachment(payload.new)
+          setMessagesByConversation((previous) => {
+            const conversationEntry = Object.entries(previous).find(([, messages]) =>
+              messages.some((message) => message.id === attachment.messageId),
+            )
+
+            if (!conversationEntry) return previous
+
+            const [conversationId, messages] = conversationEntry
+
+            return {
+              ...previous,
+              [conversationId]: messages.map((message) =>
+                message.id === attachment.messageId
+                  ? {
+                      ...message,
+                      attachments: message.attachments
+                        .filter((existing) => existing.id !== attachment.id)
+                        .concat({ ...attachment, status: "sent" }),
+                    }
+                  : message,
+              ),
+            }
+          })
+        },
+      )
+      .subscribe()
+
+    return () => {
+      supabase.removeChannel(channel)
+    }
+  }, [currentUser, getParticipants])
+
+  const selectConversation = useCallback((conversationId: string) => {
+    setSelectedConversationId(conversationId)
+  }, [])
+
+  const clearError = useCallback(() => setError(null), [])
+
+  const sendMessage = useCallback(
+    async ({
+      conversationId,
+      content,
+      topic,
+      attachments = [],
+    }: SendMessageOptions) => {
+      if (!currentUser) {
+        setError("Debes iniciar sesión para enviar mensajes.")
+        return
+      }
+
+      const trimmedContent = content.trim()
+      if (!trimmedContent) return
+
+      const temporaryId = crypto.randomUUID()
+      const createdAt = new Date().toISOString()
+
+      const participants = getParticipants(conversationId)
+      const senderProfile =
+        participants.find((participant) => participant.id === currentUser.id) ??
+        ({
+          id: currentUser.id,
+          displayName: currentUser.name,
+          avatarUrl: currentUser.avatarUrl,
+          role: currentUser.role,
+          isCurrentUser: true,
+        } satisfies ParticipantProfile)
+
+      const optimisticAttachments: MessageAttachment[] = attachments.map(
+        (file, index) => ({
+          id: `${temporaryId}-attachment-${index}`,
+          messageId: temporaryId,
+          name: file.name,
+          url: null,
+          contentType: file.type || null,
+          size: file.size ?? null,
+          createdAt,
+          status: "pending",
+        }),
+      )
+
+      const optimisticMessage: ConversationMessage = {
+        id: temporaryId,
+        conversationId,
+        content: trimmedContent,
+        topic: topic ?? null,
+        createdAt,
+        sender: senderProfile,
+        attachments: optimisticAttachments,
+        status: "pending",
+        optimisticKey: temporaryId,
+      }
+
+      setMessagesByConversation((previous) => ({
+        ...previous,
+        [conversationId]: [...(previous[conversationId] ?? []), optimisticMessage],
+      }))
+
+      setConversations((previous) => {
+        const index = previous.findIndex((item) => item.id === conversationId)
+        if (index === -1) return previous
+        const updatedConversation: ConversationPreview = {
+          ...previous[index],
+          lastMessage: optimisticMessage,
+          updatedAt: createdAt,
+        }
+        return [
+          updatedConversation,
+          ...previous.filter((item) => item.id !== conversationId),
+        ]
+      })
+
+      setSending(true)
+
+      const { data: insertedMessage, error: insertError } = await supabase
+        .from("messages")
+        .insert({
+          conversation_id: conversationId,
+          sender_id: currentUser.id,
+          sender_role: currentUser.role,
+          content: trimmedContent,
+          topic: topic ?? null,
+        })
+        .select(
+          `
+          id,
+          conversation_id,
+          content,
+          created_at,
+          sender_id,
+          sender_role,
+          topic
+        `,
+        )
+        .single()
+
+      if (insertError || !insertedMessage) {
+        setError(insertError?.message ?? "No se pudo enviar el mensaje.")
+        setMessagesByConversation((previous) => ({
+          ...previous,
+          [conversationId]: (previous[conversationId] ?? []).map((message) =>
+            message.id === temporaryId
+              ? { ...message, status: "error" }
+              : message,
+          ),
+        }))
+        setSending(false)
+        return
+      }
+
+      const uploadedAttachments: MessageAttachment[] = []
+      for (const [index, file] of attachments.entries()) {
+        const storagePath = `${conversationId}/${insertedMessage.id}/${Date.now()}-${
+          index + 1
+        }-${file.name}`
+          .replace(/\s+/g, "-")
+          .toLowerCase()
+
+        const upload = await supabase.storage
+          .from(ATTACHMENT_BUCKET)
+          .upload(storagePath, file, { upsert: false })
+
+        if (upload.error) {
+          uploadedAttachments.push({
+            id: `${insertedMessage.id}-attachment-error-${index}`,
+            messageId: insertedMessage.id,
+            name: file.name,
+            url: null,
+            contentType: file.type || null,
+            size: file.size ?? null,
+            createdAt,
+            status: "error",
+          })
+          setError(upload.error.message)
+          continue
+        }
+
+        const publicUrl = getPublicUrl(upload.data.path)
+
+        const { data: insertedAttachment, error: attachmentError } = await supabase
+          .from("attachments")
+          .insert({
+            message_id: insertedMessage.id,
+            name: file.name,
+            content_type: file.type || null,
+            size: file.size ?? null,
+            storage_path: upload.data.path,
+            url: publicUrl,
+          })
+          .select(
+            `
+            id,
+            message_id,
+            name,
+            url,
+            content_type,
+            storage_path,
+            size,
+            created_at
+          `,
+          )
+          .single()
+
+        if (attachmentError || !insertedAttachment) {
+          uploadedAttachments.push({
+            id: `${insertedMessage.id}-attachment-error-${index}`,
+            messageId: insertedMessage.id,
+            name: file.name,
+            url: publicUrl,
+            contentType: file.type || null,
+            size: file.size ?? null,
+            createdAt,
+            status: "error",
+          })
+          setError(
+            attachmentError?.message ??
+              "No se pudo guardar la información del archivo adjunto.",
+          )
+        } else {
+          uploadedAttachments.push({
+            ...formatAttachment(insertedAttachment),
+            status: "sent",
+          })
+        }
+      }
+
+      const deliveredMessage = formatMessage(
+        { ...insertedMessage, attachments: [] },
+        getParticipants(conversationId),
+        senderProfile,
+        uploadedAttachments.some((attachment) => attachment.status === "error")
+          ? "error"
+          : "sent",
+        uploadedAttachments.length ? uploadedAttachments : undefined,
+      )
+
+      setMessagesByConversation((previous) => ({
+        ...previous,
+        [conversationId]: (previous[conversationId] ?? []).map((message) =>
+          message.id === temporaryId ? deliveredMessage : message,
+        ),
+      }))
+
+      setConversations((previous) => {
+        const index = previous.findIndex((item) => item.id === conversationId)
+        if (index === -1) return previous
+        const updatedConversation: ConversationPreview = {
+          ...previous[index],
+          lastMessage: deliveredMessage,
+          updatedAt: insertedMessage.created_at,
+        }
+        return [
+          updatedConversation,
+          ...previous.filter((item) => item.id !== conversationId),
+        ]
+      })
+
+      setSending(false)
+    },
+    [currentUser, getParticipants],
+  )
+
+  const messages = useMemo(() => {
+    if (!selectedConversationId) return []
+    return messagesByConversation[selectedConversationId] ?? []
+  }, [messagesByConversation, selectedConversationId])
+
+  return {
+    conversations,
+    messages,
+    selectedConversationId,
+    loadingConversations,
+    loadingMessages,
+    sending,
+    error,
+    selectConversation,
+    clearError,
+    sendMessage,
+    refresh,
+  }
+}

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,0 +1,21 @@
+import { createClient } from "@supabase/supabase-js"
+
+import type { Database } from "@/types/supabase"
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY
+
+if (!supabaseUrl) {
+  throw new Error("VITE_SUPABASE_URL is not defined")
+}
+
+if (!supabaseAnonKey) {
+  throw new Error("VITE_SUPABASE_ANON_KEY is not defined")
+}
+
+export const supabase = createClient<Database>(supabaseUrl, supabaseAnonKey, {
+  auth: {
+    persistSession: true,
+    autoRefreshToken: true,
+  },
+})

--- a/src/pages/Messages.tsx
+++ b/src/pages/Messages.tsx
@@ -1,267 +1,419 @@
-import React, { useState } from 'react';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Textarea } from '@/components/ui/textarea';
-import { Badge } from '@/components/ui/badge';
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { MessageCircle, Send, Paperclip, Filter, Search, Users } from 'lucide-react';
+import React, { useMemo, useRef, useState } from "react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Badge } from "@/components/ui/badge";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import {
+  MessageCircle,
+  Send,
+  Paperclip,
+  Search,
+  Users,
+  Loader2,
+  AlertCircle,
+} from "lucide-react";
+import { useMessaging } from "@/hooks/useMessaging";
+import type { MessagingUser } from "@/hooks/useMessaging";
 
-interface Message {
-  id: string;
-  sender: {
-    name: string;
-    avatar?: string;
-    role: string;
-  };
-  content: string;
-  timestamp: string;
-  attachments?: Array<{
-    name: string;
-    type: string;
-    url: string;
-  }>;
-  topic?: string;
-  participants?: string[];
-}
+const currentUser: MessagingUser = {
+  id: "00000000-0000-0000-0000-000000000001",
+  name: "Usuario",
+  role: "Homebuyer",
+  avatarUrl: "https://api.dicebear.com/7.x/avataaars/svg?seed=usuario",
+};
 
 const Messages: React.FC = () => {
-  const [messageText, setMessageText] = useState('');
-  const [selectedTopic, setSelectedTopic] = useState<string>('all');
-  const [searchQuery, setSearchQuery] = useState('');
+  const [messageText, setMessageText] = useState("");
+  const [selectedTopic, setSelectedTopic] = useState<string>("all");
+  const [searchQuery, setSearchQuery] = useState("");
+  const [pendingAttachments, setPendingAttachments] = useState<File[]>([]);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
 
-  const messages: Message[] = [
-    {
-      id: '1',
-      sender: {
-        name: 'Sarah Johnson',
-        avatar: 'https://api.dicebear.com/7.x/avataaars/svg?seed=sarah',
-        role: 'Loan Officer'
-      },
-      content: 'Hi! I\'ve reviewed your application and we need a few additional documents. Please upload your most recent pay stubs when you have a chance.',
-      timestamp: '2024-01-15T10:30:00Z',
-      topic: 'Documentation',
-      participants: ['You', 'Sarah Johnson']
-    },
-    {
-      id: '2',
-      sender: {
-        name: 'Mike Chen',
-        avatar: 'https://api.dicebear.com/7.x/avataaars/svg?seed=mike',
-        role: 'Real Estate Agent'
-      },
-      content: 'Great news! The seller has accepted your offer. We can now move forward with the inspection. I\'ll coordinate with the inspector and keep you updated.',
-      timestamp: '2024-01-15T09:15:00Z',
-      topic: 'Property',
-      participants: ['You', 'Mike Chen', 'Sarah Johnson']
-    },
-    {
-      id: '3',
-      sender: {
-        name: 'You',
-        avatar: 'https://api.dicebear.com/7.x/avataaars/svg?seed=you',
-        role: 'Homebuyer'
-      },
-      content: 'Thank you for the update! I\'ll upload the pay stubs today. When do you expect to have the final approval?',
-      timestamp: '2024-01-15T11:45:00Z',
-      topic: 'Documentation',
-      participants: ['You', 'Sarah Johnson']
-    },
-    {
-      id: '4',
-      sender: {
-        name: 'Lisa Rodriguez',
-        avatar: 'https://api.dicebear.com/7.x/avataaars/svg?seed=lisa',
-        role: 'Loan Processor'
-      },
-      content: 'I\'ve processed your income verification documents. Everything looks good! We\'re on track for closing next week.',
-      timestamp: '2024-01-14T16:20:00Z',
-      topic: 'Processing',
-      participants: ['You', 'Lisa Rodriguez', 'Sarah Johnson']
-    }
-  ];
+  const {
+    conversations,
+    messages,
+    selectedConversationId,
+    selectConversation,
+    loadingConversations,
+    loadingMessages,
+    sending,
+    error,
+    clearError,
+    sendMessage,
+  } = useMessaging({ currentUser });
 
-  const topics = ['Documentation', 'Property', 'Processing', 'Closing', 'Insurance'];
+  const currentConversation = useMemo(
+    () =>
+      conversations.find(
+        (conversation) => conversation.id === selectedConversationId,
+      ) ?? null,
+    [conversations, selectedConversationId],
+  );
 
-  const filteredMessages = messages
-    .filter(message => {
-      if (selectedTopic === 'all') return true;
-      return message.topic === selectedTopic;
-    })
-    .filter(message => {
-      if (!searchQuery) return true;
-      return message.content.toLowerCase().includes(searchQuery.toLowerCase()) ||
-             message.sender.name.toLowerCase().includes(searchQuery.toLowerCase());
+  const topics = useMemo(() => {
+    const topicSet = new Set<string>();
+    messages.forEach((message) => {
+      if (message.topic) topicSet.add(message.topic);
+    });
+    return Array.from(topicSet);
+  }, [messages]);
+
+  const filteredMessages = useMemo(() => {
+    return messages
+      .filter((message) =>
+        selectedTopic === "all" ? true : message.topic === selectedTopic,
+      )
+      .filter((message) => {
+        if (!searchQuery) return true;
+        const query = searchQuery.toLowerCase();
+        return (
+          message.content.toLowerCase().includes(query) ||
+          message.sender.displayName.toLowerCase().includes(query)
+        );
+      });
+  }, [messages, selectedTopic, searchQuery]);
+
+  const handleSendMessage = async () => {
+    if (!messageText.trim() || !selectedConversationId) return;
+
+    await sendMessage({
+      conversationId: selectedConversationId,
+      content: messageText,
+      topic: selectedTopic !== "all" ? selectedTopic : undefined,
+      attachments: pendingAttachments,
     });
 
-  const handleSendMessage = () => {
-    if (messageText.trim()) {
-      console.log('Sending message:', messageText);
-      setMessageText('');
+    setMessageText("");
+    setPendingAttachments([]);
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (event.key === "Enter" && !event.shiftKey) {
+      event.preventDefault();
+      void handleSendMessage();
     }
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' && !e.shiftKey) {
-      e.preventDefault();
-      handleSendMessage();
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(event.target.files ?? []);
+    if (files.length) {
+      setPendingAttachments((previous) => [...previous, ...files]);
     }
+    event.target.value = "";
   };
 
-  const formatTimestamp = (timestamp: string) => {
-    const date = new Date(timestamp);
-    const now = new Date();
-    const diffInHours = (now.getTime() - date.getTime()) / (1000 * 60 * 60);
-    
-    if (diffInHours < 24) {
-      return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
-    } else {
-      return date.toLocaleDateString();
-    }
+  const removeAttachment = (index: number) => {
+    setPendingAttachments((previous) => previous.filter((_, idx) => idx !== index));
   };
 
   return (
     <div className="min-h-screen bg-gray-50 p-6">
-      <div className="max-w-6xl mx-auto">
-        <div className="mb-8">
-          <h1 className="text-3xl font-bold text-gray-900 mb-2">Messages</h1>
-          <p className="text-gray-600">Communicate with your mortgage team</p>
+      <div className="max-w-6xl mx-auto space-y-6">
+        <div>
+          <h1 className="text-3xl font-bold text-gray-900 mb-2">Mensajes</h1>
+          <p className="text-gray-600">
+            Gestiona tus conversaciones con el equipo hipotecario en tiempo real.
+          </p>
         </div>
 
         <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
-          {/* Sidebar */}
-          <div className="lg:col-span-1">
+          <div className="space-y-4 lg:col-span-1">
             <Card>
               <CardHeader>
-                <CardTitle className="text-lg">Filters</CardTitle>
+                <CardTitle className="text-lg">Conversaciones</CardTitle>
+                <CardDescription>
+                  {loadingConversations
+                    ? "Cargando..."
+                    : `${conversations.length} activas`}
+                </CardDescription>
               </CardHeader>
-              <CardContent className="space-y-4">
-                <div>
-                  <label className="text-sm font-medium mb-2 block">Search Messages</label>
-                  <div className="relative">
-                    <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
-                    <Input
-                      placeholder="Search..."
-                      value={searchQuery}
-                      onChange={(e) => setSearchQuery(e.target.value)}
-                      className="pl-10"
-                    />
+              <CardContent className="space-y-3">
+                <div className="relative">
+                  <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+                  <Input
+                    placeholder="Buscar..."
+                    value={searchQuery}
+                    onChange={(event) => setSearchQuery(event.target.value)}
+                    className="pl-10"
+                  />
+                </div>
+                <Select
+                  value={selectedTopic}
+                  onValueChange={setSelectedTopic}
+                  disabled={topics.length === 0}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Filtrar por tema" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">Todos los temas</SelectItem>
+                    {topics.map((topic) => (
+                      <SelectItem key={topic} value={topic}>
+                        {topic}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <ScrollArea className="h-[320px] pr-2">
+                  <div className="flex flex-col gap-2">
+                    {conversations.map((conversation) => {
+                      const participantNames = conversation.participants
+                        .filter((participant) => !participant.isCurrentUser)
+                        .map((participant) => participant.displayName)
+                        .join(", ");
+
+                      return (
+                        <Button
+                          key={conversation.id}
+                          variant={
+                            conversation.id === selectedConversationId
+                              ? "default"
+                              : "outline"
+                          }
+                          className="w-full justify-start text-left"
+                          onClick={() => selectConversation(conversation.id)}
+                        >
+                          <div className="flex flex-col items-start">
+                            <span className="font-medium">
+                              {conversation.title || participantNames || "Conversación"}
+                            </span>
+                            {conversation.lastMessage && (
+                              <span className="text-xs text-muted-foreground truncate max-w-[200px]">
+                                {conversation.lastMessage.content}
+                              </span>
+                            )}
+                          </div>
+                        </Button>
+                      );
+                    })}
+                    {conversations.length === 0 && !loadingConversations && (
+                      <p className="text-sm text-muted-foreground text-center py-6">
+                        No tienes conversaciones activas.
+                      </p>
+                    )}
                   </div>
-                </div>
-                
-                <div>
-                  <label className="text-sm font-medium mb-2 block">Topic</label>
-                  <Select value={selectedTopic} onValueChange={setSelectedTopic}>
-                    <SelectTrigger>
-                      <SelectValue placeholder="Select topic" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="all">All Topics</SelectItem>
-                      {topics.map((topic) => (
-                        <SelectItem key={topic} value={topic}>
-                          {topic}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
+                </ScrollArea>
               </CardContent>
             </Card>
           </div>
 
-          {/* Messages */}
-          <div className="lg:col-span-3">
-            <Card className="h-[600px] flex flex-col">
+          <div className="lg:col-span-3 space-y-4">
+            {error && (
+              <Alert variant="destructive" className="flex items-start gap-3">
+                <AlertCircle className="h-4 w-4" />
+                <AlertDescription className="flex-1">
+                  {error}
+                  <Button
+                    variant="link"
+                    className="h-auto p-0 ml-2"
+                    onClick={clearError}
+                  >
+                    Cerrar
+                  </Button>
+                </AlertDescription>
+              </Alert>
+            )}
+
+            <Card className="h-[640px] flex flex-col">
               <CardHeader>
                 <div className="flex items-center justify-between">
-                  <CardTitle className="flex items-center gap-2">
-                    <MessageCircle className="h-5 w-5" />
-                    Conversation
-                  </CardTitle>
+                  <div>
+                    <CardTitle className="flex items-center gap-2">
+                      <MessageCircle className="h-5 w-5" /> Conversación
+                    </CardTitle>
+                    <CardDescription>
+                      {currentConversation
+                        ? currentConversation.participants
+                            .filter((participant) => !participant.isCurrentUser)
+                            .map((participant) => participant.displayName)
+                            .join(", ") || "Conversación"
+                        : "Selecciona una conversación"}
+                    </CardDescription>
+                  </div>
                   <Badge variant="outline" className="flex items-center gap-1">
                     <Users className="h-3 w-3" />
-                    {filteredMessages.length} messages
+                    {filteredMessages.length} mensajes
                   </Badge>
                 </div>
               </CardHeader>
-              
-              <CardContent className="flex-1 flex flex-col">
-                {/* Messages List */}
-                <div className="flex-1 overflow-y-auto space-y-4 mb-4">
-                  {filteredMessages.map((message) => (
-                    <div
-                      key={message.id}
-                      className={`flex gap-3 ${
-                        message.sender.name === 'You' ? 'flex-row-reverse' : ''
-                      }`}
-                    >
-                      <Avatar className="h-8 w-8">
-                        <AvatarImage src={message.sender.avatar} />
-                        <AvatarFallback>
-                          {message.sender.name.split(' ').map(n => n[0]).join('')}
-                        </AvatarFallback>
-                      </Avatar>
-                      
-                      <div className={`flex-1 max-w-md ${
-                        message.sender.name === 'You' ? 'text-right' : ''
-                      }`}>
-                        <div className="flex items-center gap-2 mb-1">
-                          <span className="text-sm font-medium">{message.sender.name}</span>
-                          <Badge variant="secondary" className="text-xs">
-                            {message.sender.role}
-                          </Badge>
-                          <span className="text-xs text-gray-500">
-                            {formatTimestamp(message.timestamp)}
-                          </span>
-                        </div>
-                        
-                        <div className={`p-3 rounded-lg ${
-                          message.sender.name === 'You'
-                            ? 'bg-blue-500 text-white'
-                            : 'bg-gray-100 text-gray-900'
-                        }`}>
-                          <p className="text-sm">{message.content}</p>
-                          {message.topic && (
-                            <Badge 
-                              variant="outline" 
-                              className={`mt-2 text-xs ${
-                                message.sender.name === 'You' 
-                                  ? 'border-blue-200 text-blue-100' 
-                                  : ''
+
+              <CardContent className="flex-1 flex flex-col gap-4">
+                <ScrollArea className="flex-1 pr-4">
+                  <div className="flex flex-col gap-4">
+                    {loadingMessages ? (
+                      <div className="flex justify-center py-12 text-muted-foreground">
+                        <Loader2 className="h-6 w-6 animate-spin" />
+                      </div>
+                    ) : filteredMessages.length > 0 ? (
+                      filteredMessages.map((message) => (
+                        <div
+                          key={message.id}
+                          className={`flex gap-3 ${
+                            message.sender.isCurrentUser ? "flex-row-reverse" : ""
+                          }`}
+                        >
+                          <Avatar className="h-8 w-8">
+                            <AvatarImage src={message.sender.avatarUrl ?? undefined} />
+                            <AvatarFallback>
+                              {message.sender.displayName.charAt(0)}
+                            </AvatarFallback>
+                          </Avatar>
+                          <div className={`flex-1 ${
+                            message.sender.isCurrentUser ? "text-right" : ""
+                          }`}>
+                            <div
+                              className={`inline-block rounded-lg px-4 py-3 text-left ${
+                                message.sender.isCurrentUser
+                                  ? "bg-blue-500 text-white"
+                                  : "bg-muted"
                               }`}
                             >
-                              {message.topic}
-                            </Badge>
-                          )}
+                              <div className="flex items-center justify-between gap-2 mb-2">
+                                <span className="text-sm font-semibold">
+                                  {message.sender.displayName}
+                                </span>
+                                <span className="text-xs text-muted-foreground">
+                                  {new Date(message.createdAt).toLocaleString()}
+                                </span>
+                              </div>
+                              <p className="text-sm whitespace-pre-line">
+                                {message.content}
+                              </p>
+                              {message.topic && (
+                                <Badge
+                                  variant={
+                                    message.sender.isCurrentUser
+                                      ? "secondary"
+                                      : "outline"
+                                  }
+                                  className="mt-2"
+                                >
+                                  {message.topic}
+                                </Badge>
+                              )}
+                              {message.attachments.length > 0 && (
+                                <div className="flex flex-wrap gap-2 mt-3">
+                                  {message.attachments.map((attachment) => (
+                                    <div
+                                      key={attachment.id}
+                                      className="flex items-center gap-2 rounded border border-dashed px-2 py-1 text-xs bg-background/70"
+                                    >
+                                      <Paperclip className="h-3 w-3" />
+                                      <span className="max-w-[160px] truncate">
+                                        {attachment.name}
+                                      </span>
+                                      {attachment.status !== "sent" && (
+                                        <Badge
+                                          variant={
+                                            attachment.status === "error"
+                                              ? "destructive"
+                                              : "outline"
+                                          }
+                                        >
+                                          {attachment.status === "pending"
+                                            ? "Subiendo..."
+                                            : "Error"}
+                                        </Badge>
+                                      )}
+                                    </div>
+                                  ))}
+                                </div>
+                              )}
+                            </div>
+                            {message.status !== "sent" && (
+                              <p className="mt-1 text-xs text-muted-foreground">
+                                {message.status === "pending"
+                                  ? "Enviando mensaje..."
+                                  : "No se pudo entregar. Intenta nuevamente."}
+                              </p>
+                            )}
+                          </div>
                         </div>
-                      </div>
-                    </div>
-                  ))}
-                </div>
+                      ))
+                    ) : (
+                      <p className="text-center text-muted-foreground py-12">
+                        No hay mensajes en esta conversación.
+                      </p>
+                    )}
+                  </div>
+                </ScrollArea>
 
-                {/* Message Input */}
-                <div className="border-t pt-4">
-                  <div className="flex gap-2">
-                    <div className="flex-1 relative">
-                      <Textarea
-                        placeholder="Type your message..."
-                        value={messageText}
-                        onChange={(e) => setMessageText(e.target.value)}
-                        onKeyDown={handleKeyDown}
-                        className="min-h-[60px] pr-12"
+                <div className="border-t pt-4 space-y-3">
+                  <Textarea
+                    placeholder="Escribe tu mensaje..."
+                    value={messageText}
+                    onChange={(event) => setMessageText(event.target.value)}
+                    onKeyDown={handleKeyDown}
+                    disabled={!selectedConversationId}
+                  />
+                  {pendingAttachments.length > 0 && (
+                    <div className="flex flex-wrap gap-2">
+                      {pendingAttachments.map((file, index) => (
+                        <div
+                          key={`${file.name}-${index}`}
+                          className="flex items-center gap-2 rounded border px-2 py-1 text-xs"
+                        >
+                          <Paperclip className="h-3 w-3" />
+                          <span className="max-w-[160px] truncate">{file.name}</span>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="h-5 px-1"
+                            onClick={() => removeAttachment(index)}
+                          >
+                            ×
+                          </Button>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                  <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+                    <div className="flex items-center gap-2">
+                      <input
+                        ref={fileInputRef}
+                        type="file"
+                        multiple
+                        hidden
+                        onChange={handleFileChange}
                       />
                       <Button
-                        variant="ghost"
+                        variant="outline"
                         size="sm"
-                        className="absolute right-2 top-2"
+                        onClick={() => fileInputRef.current?.click()}
+                        disabled={!selectedConversationId}
                       >
-                        <Paperclip className="h-4 w-4" />
+                        <Paperclip className="h-4 w-4 mr-2" /> Adjuntar
                       </Button>
                     </div>
-                    <Button onClick={handleSendMessage} className="self-end">
-                      <Send className="h-4 w-4" />
+                    <Button
+                      onClick={() => void handleSendMessage()}
+                      disabled={
+                        !messageText.trim() || !selectedConversationId || sending
+                      }
+                    >
+                      {sending ? (
+                        <Loader2 className="h-4 w-4 animate-spin mr-2" />
+                      ) : (
+                        <Send className="h-4 w-4 mr-2" />
+                      )}
+                      {sending ? "Enviando" : "Enviar"}
                     </Button>
                   </div>
                 </div>

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -1,0 +1,178 @@
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[]
+
+export interface Database {
+  public: {
+    Tables: {
+      conversations: {
+        Row: {
+          created_at: string
+          id: string
+          title: string | null
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          title?: string | null
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          title?: string | null
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      participants: {
+        Row: {
+          avatar_url: string | null
+          conversation_id: string
+          display_name: string
+          id: string
+          inserted_at: string
+          role: string
+          user_id: string
+        }
+        Insert: {
+          avatar_url?: string | null
+          conversation_id: string
+          display_name: string
+          id?: string
+          inserted_at?: string
+          role: string
+          user_id: string
+        }
+        Update: {
+          avatar_url?: string | null
+          conversation_id?: string
+          display_name?: string
+          id?: string
+          inserted_at?: string
+          role?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "participants_conversation_id_fkey"
+            columns: ["conversation_id"]
+            referencedRelation: "conversations"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "participants_user_id_fkey"
+            columns: ["user_id"]
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          }
+        ]
+      }
+      messages: {
+        Row: {
+          content: string
+          conversation_id: string
+          created_at: string
+          id: string
+          sender_id: string
+          sender_role: string
+          topic: string | null
+        }
+        Insert: {
+          content: string
+          conversation_id: string
+          created_at?: string
+          id?: string
+          sender_id: string
+          sender_role: string
+          topic?: string | null
+        }
+        Update: {
+          content?: string
+          conversation_id?: string
+          created_at?: string
+          id?: string
+          sender_id?: string
+          sender_role?: string
+          topic?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "messages_conversation_id_fkey"
+            columns: ["conversation_id"]
+            referencedRelation: "conversations"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "messages_sender_id_fkey"
+            columns: ["sender_id"]
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          }
+        ]
+      }
+      attachments: {
+        Row: {
+          content_type: string | null
+          created_at: string
+          id: string
+          message_id: string
+          name: string
+          size: number | null
+          storage_path: string | null
+          url: string | null
+        }
+        Insert: {
+          content_type?: string | null
+          created_at?: string
+          id?: string
+          message_id: string
+          name: string
+          size?: number | null
+          storage_path?: string | null
+          url?: string | null
+        }
+        Update: {
+          content_type?: string | null
+          created_at?: string
+          id?: string
+          message_id?: string
+          name?: string
+          size?: number | null
+          storage_path?: string | null
+          url?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "attachments_message_id_fkey"
+            columns: ["message_id"]
+            referencedRelation: "messages"
+            referencedColumns: ["id"]
+          }
+        ]
+      }
+    }
+    Views: {}
+    Functions: {
+      is_conversation_member: {
+        Args: { conversation: string }
+        Returns: boolean
+      }
+      is_conversation_role: {
+        Args: { conversation: string; required_role: string }
+        Returns: boolean
+      }
+      set_updated_at: {
+        Args: Record<PropertyKey, never>
+        Returns: unknown
+      }
+    }
+    Enums: {}
+    CompositeTypes: {}
+  }
+}

--- a/src/types/tempo-routes.d.ts
+++ b/src/types/tempo-routes.d.ts
@@ -1,0 +1,4 @@
+declare module "tempo-routes" {
+  const routes: any
+  export default routes
+}

--- a/supabase/migrations/20240627120000_messaging_tables.sql
+++ b/supabase/migrations/20240627120000_messaging_tables.sql
@@ -1,0 +1,169 @@
+create extension if not exists "pgcrypto";
+
+create table if not exists public.conversations (
+  id uuid primary key default gen_random_uuid(),
+  title text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create or replace function public.set_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+create trigger conversations_set_updated_at
+  before update on public.conversations
+  for each row
+  execute function public.set_updated_at();
+
+create table if not exists public.participants (
+  id uuid primary key default gen_random_uuid(),
+  conversation_id uuid not null references public.conversations(id) on delete cascade,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  role text not null check (char_length(role) > 0),
+  display_name text not null,
+  avatar_url text,
+  inserted_at timestamptz not null default now(),
+  unique (conversation_id, user_id)
+);
+
+create index if not exists participants_conversation_idx
+  on public.participants (conversation_id);
+
+create index if not exists participants_user_idx
+  on public.participants (user_id);
+
+create table if not exists public.messages (
+  id uuid primary key default gen_random_uuid(),
+  conversation_id uuid not null references public.conversations(id) on delete cascade,
+  sender_id uuid not null references auth.users(id) on delete cascade,
+  sender_role text not null check (char_length(sender_role) > 0),
+  content text not null,
+  topic text,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists messages_conversation_idx
+  on public.messages (conversation_id, created_at desc);
+
+create index if not exists messages_sender_idx
+  on public.messages (sender_id);
+
+create table if not exists public.attachments (
+  id uuid primary key default gen_random_uuid(),
+  message_id uuid not null references public.messages(id) on delete cascade,
+  name text not null,
+  content_type text,
+  url text,
+  storage_path text,
+  size bigint,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists attachments_message_idx
+  on public.attachments (message_id);
+
+alter table public.conversations enable row level security;
+alter table public.participants enable row level security;
+alter table public.messages enable row level security;
+alter table public.attachments enable row level security;
+
+create or replace function public.is_conversation_member(conversation uuid)
+returns boolean
+language sql
+stable
+as $$
+  select exists (
+    select 1
+    from public.participants p
+    where p.conversation_id = conversation
+      and p.user_id = auth.uid()
+  );
+$$;
+
+create or replace function public.is_conversation_role(conversation uuid, required_role text)
+returns boolean
+language sql
+stable
+as $$
+  select exists (
+    select 1
+    from public.participants p
+    where p.conversation_id = conversation
+      and p.user_id = auth.uid()
+      and p.role = required_role
+  );
+$$;
+
+create policy "Members can view conversations"
+  on public.conversations
+  for select
+  using (public.is_conversation_member(id));
+
+create policy "Service role can manage conversations"
+  on public.conversations
+  for all
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');
+
+create policy "Users can manage their participant record"
+  on public.participants
+  for all
+  using (auth.uid() = user_id or auth.role() = 'service_role')
+  with check (auth.uid() = user_id or auth.role() = 'service_role');
+
+create policy "Members can read messages"
+  on public.messages
+  for select
+  using (public.is_conversation_member(conversation_id));
+
+create policy "Participants send messages with matching role"
+  on public.messages
+  for insert
+  with check (
+    auth.uid() = sender_id
+    and public.is_conversation_role(conversation_id, sender_role)
+  );
+
+create policy "Authors can update their messages"
+  on public.messages
+  for update
+  using (auth.uid() = sender_id)
+  with check (auth.uid() = sender_id);
+
+create policy "Members can view attachments"
+  on public.attachments
+  for select
+  using (
+    exists (
+      select 1
+      from public.messages m
+      where m.id = attachments.message_id
+        and public.is_conversation_member(m.conversation_id)
+    )
+  );
+
+create policy "Participants can add attachments"
+  on public.attachments
+  for insert
+  with check (
+    exists (
+      select 1
+      from public.messages m
+      where m.id = attachments.message_id
+        and auth.uid() = m.sender_id
+        and public.is_conversation_role(m.conversation_id, m.sender_role)
+    )
+  );
+
+create policy "Service role can manage attachments"
+  on public.attachments
+  for all
+  using (auth.role() = 'service_role')
+  with check (auth.role() = 'service_role');


### PR DESCRIPTION
## Summary
- add a Supabase migration that creates conversations, participants, messages, and attachments tables with role-aware RLS policies
- introduce typed Supabase client utilities and a shared `useMessaging` hook with real-time subscriptions and optimistic updates
- refactor the messaging components/pages to consume live data, handle attachments, and surface loading/error states

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e17ee38f888328888b0317f752d9ca