### PR TITLE
Integrate Supabase-backed dashboard data

### DIFF
--- a/src/components/CostBreakdown.tsx
+++ b/src/components/CostBreakdown.tsx
@@ -1,124 +1,54 @@
-import React, { useState } from "react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Progress } from "@/components/ui/progress";
-import { Separator } from "@/components/ui/separator";
-import { InfoIcon, DollarSign, AlertCircle } from "lucide-react";
-import { Badge } from "@/components/ui/badge";
+import React, { useState } from "react"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { Progress } from "@/components/ui/progress"
+import { Separator } from "@/components/ui/separator"
+import { InfoIcon, DollarSign, AlertCircle } from "lucide-react"
+import { Badge } from "@/components/ui/badge"
 import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
-} from "@/components/ui/tooltip";
-
-interface CostItem {
-  name: string;
-  amount: number;
-  description?: string;
-  isPaid?: boolean;
-}
+} from "@/components/ui/tooltip"
+import type { CostFigures, CostItem } from "@/types/dashboard"
 
 interface CostBreakdownProps {
-  loanAmount?: number;
-  downPayment?: number;
-  closingCosts?: CostItem[];
-  taxes?: CostItem[];
-  insurance?: CostItem[];
-  fees?: CostItem[];
-  totalCost?: number;
-  monthlyPayment?: number;
+  data?: CostFigures | null
+  isLoading?: boolean
+  error?: string | null
 }
 
 const CostBreakdown: React.FC<CostBreakdownProps> = ({
-  loanAmount = 250000,
-  downPayment = 50000,
-  closingCosts = [
-    {
-      name: "Origination Fee",
-      amount: 2500,
-      description: "Fee charged by the lender for processing the loan",
-    },
-    {
-      name: "Appraisal Fee",
-      amount: 500,
-      description: "Cost of the home appraisal",
-      isPaid: true,
-    },
-    {
-      name: "Title Insurance",
-      amount: 1200,
-      description:
-        "Insurance that protects the lender against problems with the title",
-    },
-    {
-      name: "Recording Fees",
-      amount: 125,
-      description: "Government fees for legally recording the new deed",
-    },
-  ],
-  taxes = [
-    {
-      name: "Property Tax (Annual)",
-      amount: 3600,
-      description: "Annual property taxes",
-    },
-    {
-      name: "Transfer Tax",
-      amount: 1500,
-      description: "Tax on transferring the property title",
-    },
-  ],
-  insurance = [
-    {
-      name: "Homeowner's Insurance (Annual)",
-      amount: 1200,
-      description: "Annual insurance premium",
-    },
-    {
-      name: "Mortgage Insurance",
-      amount: 1800,
-      description: "Annual private mortgage insurance",
-    },
-  ],
-  fees = [
-    {
-      name: "Attorney Fees",
-      amount: 1500,
-      description: "Legal fees for closing",
-    },
-    {
-      name: "Home Inspection",
-      amount: 450,
-      description: "Cost of home inspection",
-      isPaid: true,
-    },
-    {
-      name: "HOA Transfer Fee",
-      amount: 250,
-      description: "Fee for transferring HOA membership",
-    },
-  ],
-  totalCost = 300000,
-  monthlyPayment = 1450,
+  data,
+  isLoading = false,
+  error = null,
 }) => {
-  const [activeTab, setActiveTab] = useState("summary");
+  const [activeTab, setActiveTab] = useState("summary")
 
-  const totalClosingCosts = closingCosts.reduce(
-    (sum, item) => sum + item.amount,
-    0,
-  );
-  const totalTaxes = taxes.reduce((sum, item) => sum + item.amount, 0);
-  const totalInsurance = insurance.reduce((sum, item) => sum + item.amount, 0);
-  const totalFees = fees.reduce((sum, item) => sum + item.amount, 0);
+  const closingCosts = data?.closingCosts ?? []
+  const taxes = data?.taxes ?? []
+  const insurance = data?.insurance ?? []
+  const fees = data?.fees ?? []
 
-  const upfrontCosts = downPayment + totalClosingCosts + totalFees;
-  const upfrontPercentage = (upfrontCosts / totalCost) * 100;
+  const totalClosingCosts = closingCosts.reduce((sum, item) => sum + item.amount, 0)
+  const totalTaxes = taxes.reduce((sum, item) => sum + item.amount, 0)
+  const totalInsurance = insurance.reduce((sum, item) => sum + item.amount, 0)
+  const totalFees = fees.reduce((sum, item) => sum + item.amount, 0)
+
+  const upfrontCosts =
+    (data?.downPayment ?? 0) + totalClosingCosts + totalFees
+  const upfrontPercentage = data?.totalCost
+    ? (upfrontCosts / data.totalCost) * 100
+    : 0
+  const downPaymentPercentage = data?.totalCost
+    ? Math.round((data.downPayment / data.totalCost) * 100)
+    : 0
 
   const renderCostItems = (items: CostItem[]) => (
     <div className="space-y-2">
-      {items.map((item, index) => (
-        <div key={index} className="flex justify-between items-center">
+      {items.map((item) => (
+        <div key={item.id ?? item.name} className="flex justify-between items-center">
           <div className="flex items-center">
             <span className="font-medium">{item.name}</span>
             {item.isPaid && (
@@ -143,7 +73,195 @@ const CostBreakdown: React.FC<CostBreakdownProps> = ({
         </div>
       ))}
     </div>
-  );
+  )
+
+  const renderContent = () => {
+    if (isLoading) {
+      return (
+        <div className="flex items-center justify-center py-6 text-sm text-muted-foreground">
+          Loading cost breakdown...
+        </div>
+      )
+    }
+
+    if (error) {
+      return (
+        <div className="flex items-center justify-center py-6 text-sm text-red-500">
+          <AlertCircle className="mr-2 h-4 w-4" />
+          {error}
+        </div>
+      )
+    }
+
+    if (!data) {
+      return (
+        <div className="flex items-center justify-center py-6 text-sm text-muted-foreground">
+          No cost breakdown data available.
+        </div>
+      )
+    }
+
+    return (
+      <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
+        <TabsList className="grid w-full grid-cols-4 mb-6">
+          <TabsTrigger value="summary">Summary</TabsTrigger>
+          <TabsTrigger value="closing">Closing Costs</TabsTrigger>
+          <TabsTrigger value="monthly">Monthly Payment</TabsTrigger>
+          <TabsTrigger value="all">All Costs</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="summary" className="space-y-4">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <div className="space-y-4">
+              <div>
+                <h3 className="text-lg font-semibold mb-2">Loan Overview</h3>
+                <div className="grid grid-cols-2 gap-2">
+                  <div className="text-sm text-muted-foreground">Purchase Price:</div>
+                  <div className="text-sm font-medium text-right">
+                    ${data.totalCost.toLocaleString()}
+                  </div>
+                  <div className="text-sm text-muted-foreground">Loan Amount:</div>
+                  <div className="text-sm font-medium text-right">
+                    ${data.loanAmount.toLocaleString()}
+                  </div>
+                  <div className="text-sm text-muted-foreground">Down Payment:</div>
+                  <div className="text-sm font-medium text-right">
+                    ${data.downPayment.toLocaleString()} ({
+                      downPaymentPercentage
+                    }%)
+                  </div>
+                </div>
+              </div>
+
+              <div>
+                <h3 className="text-lg font-semibold mb-2">Upfront Costs</h3>
+                <div className="mb-2">
+                  <div className="flex justify-between mb-1">
+                    <span className="text-sm text-muted-foreground">
+                      Progress
+                    </span>
+                    <span className="text-sm font-medium">
+                      {Math.round(upfrontPercentage)}%
+                    </span>
+                  </div>
+                  <Progress value={upfrontPercentage} className="h-2" />
+                </div>
+                <div className="space-y-2 text-sm">
+                  <div className="flex justify-between">
+                    <span>Down Payment</span>
+                    <span>${data.downPayment.toLocaleString()}</span>
+                  </div>
+                  <div className="flex justify-between">
+                    <span>Closing Costs</span>
+                    <span>${totalClosingCosts.toLocaleString()}</span>
+                  </div>
+                  <div className="flex justify-between">
+                    <span>Fees</span>
+                    <span>${totalFees.toLocaleString()}</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div className="space-y-4">
+              <div>
+                <h3 className="text-lg font-semibold mb-2">Monthly Payment</h3>
+                <div className="bg-blue-50 p-4 rounded-lg">
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm text-blue-700">Estimated Monthly Payment</span>
+                    <span className="text-2xl font-bold text-blue-800">
+                      ${data.monthlyPayment.toLocaleString()}
+                    </span>
+                  </div>
+                  <Separator className="my-4" />
+                  <div className="space-y-2 text-sm text-blue-700">
+                    <div className="flex justify-between">
+                      <span>Principal & Interest</span>
+                      <span>
+                        ${
+                          (data.monthlyPayment - totalTaxes / 12 - totalInsurance / 12).toLocaleString()
+                        }
+                      </span>
+                    </div>
+                    <div className="flex justify-between">
+                      <span>Taxes</span>
+                      <span>${Math.round(totalTaxes / 12).toLocaleString()}</span>
+                    </div>
+                    <div className="flex justify-between">
+                      <span>Insurance</span>
+                      <span>${Math.round(totalInsurance / 12).toLocaleString()}</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <div>
+                <h3 className="text-lg font-semibold mb-2">Tax & Insurance Summary</h3>
+                <div className="space-y-2 text-sm">
+                  <div className="flex justify-between">
+                    <span>Annual Taxes</span>
+                    <span>${totalTaxes.toLocaleString()}</span>
+                  </div>
+                  <div className="flex justify-between">
+                    <span>Annual Insurance</span>
+                    <span>${totalInsurance.toLocaleString()}</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </TabsContent>
+
+        <TabsContent value="closing" className="space-y-4">
+          <div>
+            <h3 className="text-lg font-semibold mb-2">Closing Costs</h3>
+            {renderCostItems(closingCosts)}
+          </div>
+        </TabsContent>
+
+        <TabsContent value="monthly" className="space-y-4">
+          <div className="space-y-2 text-sm">
+            <div className="flex justify-between">
+              <span>Monthly Mortgage Payment</span>
+              <span>${data.monthlyPayment.toLocaleString()}</span>
+            </div>
+            <div className="flex justify-between">
+              <span>Monthly Taxes</span>
+              <span>${Math.round(totalTaxes / 12).toLocaleString()}</span>
+            </div>
+            <div className="flex justify-between">
+              <span>Monthly Insurance</span>
+              <span>${Math.round(totalInsurance / 12).toLocaleString()}</span>
+            </div>
+          </div>
+        </TabsContent>
+
+        <TabsContent value="all" className="space-y-4">
+          <div>
+            <h3 className="text-lg font-semibold mb-2">All Costs</h3>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+              <div>
+                <h4 className="text-md font-semibold mb-2">Closing Costs</h4>
+                {renderCostItems(closingCosts)}
+              </div>
+              <div>
+                <h4 className="text-md font-semibold mb-2">Fees</h4>
+                {renderCostItems(fees)}
+              </div>
+              <div>
+                <h4 className="text-md font-semibold mb-2">Taxes</h4>
+                {renderCostItems(taxes)}
+              </div>
+              <div>
+                <h4 className="text-md font-semibold mb-2">Insurance</h4>
+                {renderCostItems(insurance)}
+              </div>
+            </div>
+          </div>
+        </TabsContent>
+      </Tabs>
+    )
+  }
 
   return (
     <Card className="w-full bg-white shadow-md">
@@ -153,321 +271,9 @@ const CostBreakdown: React.FC<CostBreakdownProps> = ({
           Cost Breakdown
         </CardTitle>
       </CardHeader>
-      <CardContent className="p-6">
-        <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
-          <TabsList className="grid w-full grid-cols-4 mb-6">
-            <TabsTrigger value="summary">Summary</TabsTrigger>
-            <TabsTrigger value="closing">Closing Costs</TabsTrigger>
-            <TabsTrigger value="monthly">Monthly Payment</TabsTrigger>
-            <TabsTrigger value="all">All Costs</TabsTrigger>
-          </TabsList>
-
-          <TabsContent value="summary" className="space-y-4">
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-              <div className="space-y-4">
-                <div>
-                  <h3 className="text-lg font-semibold mb-2">Loan Overview</h3>
-                  <div className="grid grid-cols-2 gap-2">
-                    <div className="text-sm text-muted-foreground">
-                      Purchase Price:
-                    </div>
-                    <div className="text-sm font-medium text-right">
-                      ${totalCost.toLocaleString()}
-                    </div>
-                    <div className="text-sm text-muted-foreground">
-                      Loan Amount:
-                    </div>
-                    <div className="text-sm font-medium text-right">
-                      ${loanAmount.toLocaleString()}
-                    </div>
-                    <div className="text-sm text-muted-foreground">
-                      Down Payment:
-                    </div>
-                    <div className="text-sm font-medium text-right">
-                      ${downPayment.toLocaleString()} (
-                      {Math.round((downPayment / totalCost) * 100)}%)
-                    </div>
-                  </div>
-                </div>
-
-                <div>
-                  <h3 className="text-lg font-semibold mb-2">Upfront Costs</h3>
-                  <div className="mb-2">
-                    <div className="flex justify-between mb-1">
-                      <span className="text-sm text-muted-foreground">
-                        Progress
-                      </span>
-                      <span className="text-sm font-medium">
-                        ${upfrontCosts.toLocaleString()}
-                      </span>
-                    </div>
-                    <Progress value={upfrontPercentage} className="h-2" />
-                  </div>
-                  <div className="grid grid-cols-2 gap-2">
-                    <div className="text-sm text-muted-foreground">
-                      Down Payment:
-                    </div>
-                    <div className="text-sm font-medium text-right">
-                      ${downPayment.toLocaleString()}
-                    </div>
-                    <div className="text-sm text-muted-foreground">
-                      Closing Costs:
-                    </div>
-                    <div className="text-sm font-medium text-right">
-                      ${totalClosingCosts.toLocaleString()}
-                    </div>
-                    <div className="text-sm text-muted-foreground">
-                      Additional Fees:
-                    </div>
-                    <div className="text-sm font-medium text-right">
-                      ${totalFees.toLocaleString()}
-                    </div>
-                  </div>
-                </div>
-              </div>
-
-              <div className="space-y-4">
-                <div>
-                  <h3 className="text-lg font-semibold mb-2">
-                    Monthly Payment
-                  </h3>
-                  <div className="p-4 bg-blue-50 rounded-lg border border-blue-100">
-                    <div className="text-center">
-                      <span className="text-3xl font-bold text-blue-800">
-                        ${monthlyPayment}
-                      </span>
-                      <p className="text-sm text-muted-foreground mt-1">
-                        Estimated monthly payment
-                      </p>
-                    </div>
-                    <Separator className="my-4" />
-                    <div className="grid grid-cols-2 gap-2">
-                      <div className="text-sm text-muted-foreground">
-                        Principal & Interest:
-                      </div>
-                      <div className="text-sm font-medium text-right">
-                        ${(monthlyPayment - 300 - 150).toLocaleString()}
-                      </div>
-                      <div className="text-sm text-muted-foreground">
-                        Property Taxes:
-                      </div>
-                      <div className="text-sm font-medium text-right">$300</div>
-                      <div className="text-sm text-muted-foreground">
-                        Insurance:
-                      </div>
-                      <div className="text-sm font-medium text-right">$150</div>
-                    </div>
-                  </div>
-                </div>
-
-                <div className="p-4 bg-amber-50 rounded-lg border border-amber-100 flex items-start">
-                  <AlertCircle className="h-5 w-5 text-amber-500 mr-2 mt-0.5" />
-                  <div>
-                    <h4 className="font-medium text-amber-800">
-                      Important Note
-                    </h4>
-                    <p className="text-sm text-amber-700">
-                      These are estimated costs and may change during the
-                      mortgage process. Final costs will be confirmed before
-                      closing.
-                    </p>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </TabsContent>
-
-          <TabsContent value="closing" className="space-y-6">
-            <div>
-              <h3 className="text-lg font-semibold mb-3">Closing Costs</h3>
-              {renderCostItems(closingCosts)}
-              <div className="flex justify-between mt-4 pt-2 border-t">
-                <span className="font-semibold">Total Closing Costs</span>
-                <span className="font-bold">
-                  ${totalClosingCosts.toLocaleString()}
-                </span>
-              </div>
-            </div>
-
-            <div>
-              <h3 className="text-lg font-semibold mb-3">Taxes</h3>
-              {renderCostItems(taxes)}
-              <div className="flex justify-between mt-4 pt-2 border-t">
-                <span className="font-semibold">Total Taxes</span>
-                <span className="font-bold">
-                  ${totalTaxes.toLocaleString()}
-                </span>
-              </div>
-            </div>
-
-            <div>
-              <h3 className="text-lg font-semibold mb-3">Additional Fees</h3>
-              {renderCostItems(fees)}
-              <div className="flex justify-between mt-4 pt-2 border-t">
-                <span className="font-semibold">Total Additional Fees</span>
-                <span className="font-bold">${totalFees.toLocaleString()}</span>
-              </div>
-            </div>
-          </TabsContent>
-
-          <TabsContent value="monthly" className="space-y-6">
-            <div className="p-6 bg-blue-50 rounded-lg border border-blue-100">
-              <div className="text-center mb-6">
-                <span className="text-4xl font-bold text-blue-800">
-                  ${monthlyPayment}
-                </span>
-                <p className="text-sm text-muted-foreground mt-1">
-                  Estimated monthly payment
-                </p>
-              </div>
-
-              <div className="space-y-4">
-                <div>
-                  <div className="flex justify-between mb-1">
-                    <span className="text-sm font-medium">
-                      Principal & Interest
-                    </span>
-                    <span className="text-sm font-medium">
-                      ${(monthlyPayment - 300 - 150).toLocaleString()}
-                    </span>
-                  </div>
-                  <Progress value={69} className="h-2" />
-                </div>
-
-                <div>
-                  <div className="flex justify-between mb-1">
-                    <span className="text-sm font-medium">Property Taxes</span>
-                    <span className="text-sm font-medium">$300</span>
-                  </div>
-                  <Progress value={21} className="h-2" />
-                </div>
-
-                <div>
-                  <div className="flex justify-between mb-1">
-                    <span className="text-sm font-medium">Insurance</span>
-                    <span className="text-sm font-medium">$150</span>
-                  </div>
-                  <Progress value={10} className="h-2" />
-                </div>
-              </div>
-            </div>
-
-            <div>
-              <h3 className="text-lg font-semibold mb-3">Insurance Costs</h3>
-              {renderCostItems(insurance)}
-              <div className="flex justify-between mt-4 pt-2 border-t">
-                <span className="font-semibold">Total Insurance Costs</span>
-                <span className="font-bold">
-                  ${totalInsurance.toLocaleString()}
-                </span>
-              </div>
-            </div>
-          </TabsContent>
-
-          <TabsContent value="all" className="space-y-6">
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-              <div>
-                <h3 className="text-lg font-semibold mb-3">Loan Details</h3>
-                <div className="space-y-2">
-                  <div className="flex justify-between">
-                    <span className="text-muted-foreground">
-                      Purchase Price
-                    </span>
-                    <span className="font-medium">
-                      ${totalCost.toLocaleString()}
-                    </span>
-                  </div>
-                  <div className="flex justify-between">
-                    <span className="text-muted-foreground">Loan Amount</span>
-                    <span className="font-medium">
-                      ${loanAmount.toLocaleString()}
-                    </span>
-                  </div>
-                  <div className="flex justify-between">
-                    <span className="text-muted-foreground">Down Payment</span>
-                    <span className="font-medium">
-                      ${downPayment.toLocaleString()}
-                    </span>
-                  </div>
-                  <div className="flex justify-between">
-                    <span className="text-muted-foreground">
-                      Down Payment Percentage
-                    </span>
-                    <span className="font-medium">
-                      {Math.round((downPayment / totalCost) * 100)}%
-                    </span>
-                  </div>
-                </div>
-              </div>
-
-              <div>
-                <h3 className="text-lg font-semibold mb-3">Total Costs</h3>
-                <div className="space-y-2">
-                  <div className="flex justify-between">
-                    <span className="text-muted-foreground">Closing Costs</span>
-                    <span className="font-medium">
-                      ${totalClosingCosts.toLocaleString()}
-                    </span>
-                  </div>
-                  <div className="flex justify-between">
-                    <span className="text-muted-foreground">Taxes</span>
-                    <span className="font-medium">
-                      ${totalTaxes.toLocaleString()}
-                    </span>
-                  </div>
-                  <div className="flex justify-between">
-                    <span className="text-muted-foreground">Insurance</span>
-                    <span className="font-medium">
-                      ${totalInsurance.toLocaleString()}
-                    </span>
-                  </div>
-                  <div className="flex justify-between">
-                    <span className="text-muted-foreground">
-                      Additional Fees
-                    </span>
-                    <span className="font-medium">
-                      ${totalFees.toLocaleString()}
-                    </span>
-                  </div>
-                  <Separator className="my-2" />
-                  <div className="flex justify-between">
-                    <span className="font-semibold">Total Upfront Costs</span>
-                    <span className="font-bold">
-                      ${upfrontCosts.toLocaleString()}
-                    </span>
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            <div>
-              <h3 className="text-lg font-semibold mb-3">
-                All Costs Breakdown
-              </h3>
-              <div className="space-y-6">
-                <div>
-                  <h4 className="font-medium mb-2">Closing Costs</h4>
-                  {renderCostItems(closingCosts)}
-                </div>
-                <div>
-                  <h4 className="font-medium mb-2">Taxes</h4>
-                  {renderCostItems(taxes)}
-                </div>
-                <div>
-                  <h4 className="font-medium mb-2">Insurance</h4>
-                  {renderCostItems(insurance)}
-                </div>
-                <div>
-                  <h4 className="font-medium mb-2">Additional Fees</h4>
-                  {renderCostItems(fees)}
-                </div>
-              </div>
-            </div>
-          </TabsContent>
-        </Tabs>
-      </CardContent>
+      <CardContent className="p-6">{renderContent()}</CardContent>
     </Card>
-  );
-};
+  )
+}
 
-export default CostBreakdown;
+export default CostBreakdown

--- a/src/components/MortgageTimeline.tsx
+++ b/src/components/MortgageTimeline.tsx
@@ -1,64 +1,62 @@
-import React from "react";
-import { Card, CardContent } from "./ui/card";
-import { Badge } from "./ui/badge";
-import { Progress } from "./ui/progress";
-import { Button } from "./ui/button";
+import React from "react"
+import type { TimelineStage } from "@/types/dashboard"
+import { Card, CardContent } from "./ui/card"
+import { Badge } from "./ui/badge"
+import { Progress } from "./ui/progress"
+import { Button } from "./ui/button"
 import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
-} from "./ui/tooltip";
+} from "./ui/tooltip"
 import {
   CheckCircle,
   Clock,
   AlertCircle,
   ChevronRight,
   ChevronDown,
-} from "lucide-react";
-
-type TimelineStage = {
-  id: string;
-  name: string;
-  status: "completed" | "in-progress" | "pending";
-  tasks: {
-    id: string;
-    name: string;
-    completed: boolean;
-    deadline?: string;
-  }[];
-  description: string;
-};
+} from "lucide-react"
 
 type MortgageTimelineProps = {
-  stages?: TimelineStage[];
-  currentStageId?: string;
-  progress?: number;
-};
+  stages?: TimelineStage[]
+  currentStageId?: string | null
+  progress?: number
+  isLoading?: boolean
+  error?: string | null
+}
 
 const MortgageTimeline = ({
-  stages = defaultStages,
-  currentStageId = "approval",
-  progress = 35,
+  stages,
+  currentStageId,
+  progress = 0,
+  isLoading = false,
+  error = null,
 }: MortgageTimelineProps) => {
   const [expandedStage, setExpandedStage] = React.useState<string | null>(
-    currentStageId,
-  );
+    currentStageId ?? null,
+  )
+
+  React.useEffect(() => {
+    setExpandedStage(currentStageId ?? null)
+  }, [currentStageId])
+
+  const timelineStages = stages ?? []
 
   const toggleStage = (stageId: string) => {
-    setExpandedStage(expandedStage === stageId ? null : stageId);
-  };
+    setExpandedStage(expandedStage === stageId ? null : stageId)
+  }
 
   const getStatusIcon = (status: TimelineStage["status"]) => {
     switch (status) {
       case "completed":
-        return <CheckCircle className="h-5 w-5 text-green-500" />;
+        return <CheckCircle className="h-5 w-5 text-green-500" />
       case "in-progress":
-        return <Clock className="h-5 w-5 text-blue-500" />;
+        return <Clock className="h-5 w-5 text-blue-500" />
       case "pending":
-        return <AlertCircle className="h-5 w-5 text-gray-400" />;
+        return <AlertCircle className="h-5 w-5 text-gray-400" />
     }
-  };
+  }
 
   const getStatusBadge = (status: TimelineStage["status"]) => {
     switch (status) {
@@ -67,21 +65,21 @@ const MortgageTimeline = ({
           <Badge variant="secondary" className="bg-green-100 text-green-800">
             Completed
           </Badge>
-        );
+        )
       case "in-progress":
         return (
           <Badge variant="secondary" className="bg-blue-100 text-blue-800">
             In Progress
           </Badge>
-        );
+        )
       case "pending":
         return (
           <Badge variant="outline" className="text-gray-500">
             Pending
           </Badge>
-        );
+        )
     }
-  };
+  }
 
   return (
     <Card className="w-full bg-white shadow-sm">
@@ -104,162 +102,116 @@ const MortgageTimeline = ({
           </div>
         </div>
 
-        <div className="relative">
-          {/* Timeline connector line */}
-          <div className="absolute left-[22px] top-8 bottom-8 w-0.5 bg-gray-200"></div>
+        {isLoading ? (
+          <div className="py-6 text-center text-sm text-gray-500">
+            Loading mortgage timeline...
+          </div>
+        ) : error ? (
+          <div className="py-6 text-center text-sm text-red-500">{error}</div>
+        ) : timelineStages.length === 0 ? (
+          <div className="py-6 text-center text-sm text-gray-500">
+            No timeline stages available.
+          </div>
+        ) : (
+          <div className="relative">
+            <div className="absolute left-[22px] top-8 bottom-8 w-0.5 bg-gray-200"></div>
 
-          {/* Timeline stages */}
-          <div className="space-y-6">
-            {stages.map((stage, index) => (
-              <div key={stage.id} className="relative">
-                <div
-                  className={`flex items-start gap-4 cursor-pointer ${expandedStage === stage.id ? "mb-4" : ""}`}
-                  onClick={() => toggleStage(stage.id)}
-                >
+            <div className="space-y-6">
+              {timelineStages.map((stage) => (
+                <div key={stage.id} className="relative">
                   <div
-                    className={`rounded-full p-1 z-10 ${stage.status === "completed" ? "bg-green-100" : stage.status === "in-progress" ? "bg-blue-100" : "bg-gray-100"}`}
+                    className={`flex items-start gap-4 cursor-pointer ${expandedStage === stage.id ? "mb-4" : ""}`}
+                    onClick={() => toggleStage(stage.id)}
                   >
-                    {getStatusIcon(stage.status)}
-                  </div>
-                  <div className="flex-1">
-                    <div className="flex items-center justify-between">
-                      <div>
-                        <h3 className="text-lg font-medium text-gray-800">
-                          {stage.name}
-                        </h3>
-                        <p className="text-sm text-gray-500">
-                          {stage.description}
-                        </p>
-                      </div>
-                      <div className="flex items-center gap-3">
-                        {getStatusBadge(stage.status)}
-                        {expandedStage === stage.id ? (
-                          <ChevronDown className="h-5 w-5 text-gray-400" />
-                        ) : (
-                          <ChevronRight className="h-5 w-5 text-gray-400" />
-                        )}
-                      </div>
+                    <div
+                      className={`rounded-full p-1 z-10 ${stage.status === "completed" ? "bg-green-100" : stage.status === "in-progress" ? "bg-blue-100" : "bg-gray-100"}`}
+                    >
+                      {getStatusIcon(stage.status)}
                     </div>
-                  </div>
-                </div>
-
-                {/* Expanded content */}
-                {expandedStage === stage.id && (
-                  <div className="ml-12 pl-4 border-l border-dashed border-gray-200">
-                    <div className="space-y-3">
-                      {stage.tasks.map((task) => (
-                        <div
-                          key={task.id}
-                          className="flex items-center justify-between bg-gray-50 p-3 rounded-md"
-                        >
-                          <div className="flex items-center gap-3">
-                            <div
-                              className={`w-5 h-5 rounded-full flex items-center justify-center ${task.completed ? "bg-green-500" : "bg-gray-200"}`}
-                            >
-                              {task.completed && (
-                                <CheckCircle className="h-4 w-4 text-white" />
-                              )}
-                            </div>
-                            <span
-                              className={`${task.completed ? "text-gray-600" : "text-gray-800"}`}
-                            >
-                              {task.name}
-                            </span>
-                          </div>
-                          {task.deadline && (
-                            <TooltipProvider>
-                              <Tooltip>
-                                <TooltipTrigger asChild>
-                                  <div className="text-xs text-gray-500 flex items-center gap-1">
-                                    <Clock className="h-3 w-3" />
-                                    {task.deadline}
-                                  </div>
-                                </TooltipTrigger>
-                                <TooltipContent>
-                                  <p>Deadline</p>
-                                </TooltipContent>
-                              </Tooltip>
-                            </TooltipProvider>
+                    <div className="flex-1">
+                      <div className="flex items-center justify-between">
+                        <div>
+                          <h3 className="text-lg font-medium text-gray-800">
+                            {stage.name}
+                          </h3>
+                          <p className="text-sm text-gray-500">
+                            {stage.description}
+                          </p>
+                        </div>
+                        <div className="flex items-center gap-3">
+                          {getStatusBadge(stage.status)}
+                          {expandedStage === stage.id ? (
+                            <ChevronDown className="h-5 w-5 text-gray-400" />
+                          ) : (
+                            <ChevronRight className="h-5 w-5 text-gray-400" />
                           )}
                         </div>
-                      ))}
-                    </div>
-
-                    {stage.status !== "completed" && (
-                      <div className="mt-4">
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          className="text-blue-600 border-blue-200 hover:bg-blue-50"
-                        >
-                          View Details
-                        </Button>
                       </div>
-                    )}
+                    </div>
                   </div>
-                )}
-              </div>
-            ))}
+
+                  {expandedStage === stage.id && (
+                    <div className="ml-12 pl-4 border-l border-dashed border-gray-200">
+                      <div className="space-y-3">
+                        {stage.tasks.map((task) => (
+                          <div
+                            key={task.id}
+                            className="flex items-center justify-between bg-gray-50 p-3 rounded-md"
+                          >
+                            <div className="flex items-center gap-3">
+                              <div
+                                className={`w-5 h-5 rounded-full flex items-center justify-center ${task.completed ? "bg-green-500" : "bg-gray-200"}`}
+                              >
+                                {task.completed && (
+                                  <CheckCircle className="h-4 w-4 text-white" />
+                                )}
+                              </div>
+                              <span
+                                className={`${task.completed ? "text-gray-600" : "text-gray-800"}`}
+                              >
+                                {task.name}
+                              </span>
+                            </div>
+                            {task.deadline && (
+                              <TooltipProvider>
+                                <Tooltip>
+                                  <TooltipTrigger asChild>
+                                    <div className="text-xs text-gray-500 flex items-center gap-1">
+                                      <Clock className="h-3 w-3" />
+                                      {task.deadline}
+                                    </div>
+                                  </TooltipTrigger>
+                                  <TooltipContent>
+                                    <p>Deadline</p>
+                                  </TooltipContent>
+                                </Tooltip>
+                              </TooltipProvider>
+                            )}
+                          </div>
+                        ))}
+                      </div>
+
+                      {stage.status !== "completed" && (
+                        <div className="mt-4">
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            className="text-blue-600 border-blue-200 hover:bg-blue-50"
+                          >
+                            View Details
+                          </Button>
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
           </div>
-        </div>
+        )}
       </CardContent>
     </Card>
-  );
-};
+  )
+}
 
-// Default mock data
-const defaultStages: TimelineStage[] = [
-  {
-    id: "pre-approval",
-    name: "Pre-Approval",
-    status: "completed",
-    description: "Initial qualification for mortgage financing",
-    tasks: [
-      { id: "t1", name: "Submit financial documents", completed: true },
-      { id: "t2", name: "Credit check", completed: true },
-      { id: "t3", name: "Receive pre-approval letter", completed: true },
-    ],
-  },
-  {
-    id: "approval",
-    name: "Loan Application",
-    status: "in-progress",
-    description: "Formal mortgage application process",
-    tasks: [
-      { id: "t4", name: "Complete loan application", completed: true },
-      { id: "t5", name: "Submit income verification", completed: true },
-      {
-        id: "t6",
-        name: "Property appraisal",
-        completed: false,
-        deadline: "Jun 15, 2023",
-      },
-      { id: "t7", name: "Underwriting review", completed: false },
-    ],
-  },
-  {
-    id: "processing",
-    name: "Loan Processing",
-    status: "pending",
-    description: "Review and verification of all documentation",
-    tasks: [
-      { id: "t8", name: "Document verification", completed: false },
-      { id: "t9", name: "Title search", completed: false },
-      { id: "t10", name: "Insurance verification", completed: false },
-    ],
-  },
-  {
-    id: "closing",
-    name: "Closing",
-    status: "pending",
-    description: "Final review and signing of loan documents",
-    tasks: [
-      { id: "t11", name: "Final walkthrough", completed: false },
-      { id: "t12", name: "Closing disclosure review", completed: false },
-      { id: "t13", name: "Sign closing documents", completed: false },
-      { id: "t14", name: "Funding and key transfer", completed: false },
-    ],
-  },
-];
-
-export default MortgageTimeline;
+export default MortgageTimeline

--- a/src/components/home.tsx
+++ b/src/components/home.tsx
@@ -1,8 +1,8 @@
-import React from "react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { Button } from "@/components/ui/button";
+import React from "react"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { Button } from "@/components/ui/button"
 import {
   Bell,
   MessageSquare,
@@ -11,36 +11,132 @@ import {
   Settings,
   User,
   ChevronRight,
-} from "lucide-react";
-import MortgageTimeline from "./MortgageTimeline";
-import DocumentManager from "./DocumentManager";
-import MessagingSystem from "./MessagingSystem";
-import CostBreakdown from "./CostBreakdown";
+  AlertCircle,
+} from "lucide-react"
+import MortgageTimeline from "./MortgageTimeline"
+import DocumentManager from "./DocumentManager"
+import MessagingSystem from "./MessagingSystem"
+import CostBreakdown from "./CostBreakdown"
+import {
+  fetchAuthenticatedUser,
+  fetchLoanProgress,
+  fetchTimelineStages,
+  fetchCostFigures,
+} from "@/lib/dashboard-data"
+import type {
+  CostFigures,
+  DashboardUser,
+  LoanProgressSummary,
+  TimelineStage,
+} from "@/types/dashboard"
 
 const HomePage = () => {
-  // Mock user data - in a real app this would come from authentication
-  const user = {
-    name: "Carlos Rodriguez",
-    role: "homebuyer", // Could be: 'homebuyer', 'agent', 'lender', 'processor'
-    avatar: "https://api.dicebear.com/7.x/avataaars/svg?seed=Carlos",
-    notifications: 3,
-  };
+  const [user, setUser] = React.useState<DashboardUser | null>(null)
+  const [loanData, setLoanData] = React.useState<LoanProgressSummary | null>(null)
+  const [timelineStages, setTimelineStages] = React.useState<TimelineStage[]>([])
+  const [costFigures, setCostFigures] = React.useState<CostFigures | null>(null)
+  const [loading, setLoading] = React.useState(true)
+  const [globalError, setGlobalError] = React.useState<string | null>(null)
+  const [userError, setUserError] = React.useState<string | null>(null)
+  const [loanError, setLoanError] = React.useState<string | null>(null)
+  const [timelineError, setTimelineError] = React.useState<string | null>(null)
+  const [costError, setCostError] = React.useState<string | null>(null)
 
-  // Mock loan data
-  const loanData = {
-    id: "LOAN-2023-001",
-    status: "In Progress",
-    currentStage: "Document Review",
-    progress: 45, // percentage
-    pendingTasks: 2,
-    agent: "Maria Lopez",
-    lender: "First National Bank",
-    processor: "John Smith",
-  };
+  React.useEffect(() => {
+    let isMounted = true
+
+    const loadDashboardData = async () => {
+      setLoading(true)
+      setGlobalError(null)
+      setUserError(null)
+      setLoanError(null)
+      setTimelineError(null)
+      setCostError(null)
+
+      const results = await Promise.allSettled([
+        fetchAuthenticatedUser(),
+        fetchLoanProgress(),
+        fetchTimelineStages(),
+        fetchCostFigures(),
+      ])
+
+      if (!isMounted) {
+        return
+      }
+
+      const errors: string[] = []
+
+      const [userResult, loanResult, timelineResult, costResult] = results
+
+      if (userResult.status === "fulfilled") {
+        setUser(userResult.value)
+        setUserError(null)
+      } else {
+        const message =
+          userResult.reason instanceof Error
+            ? userResult.reason.message
+            : "Unable to load user information."
+        errors.push(message)
+        setUserError(message)
+      }
+
+      if (loanResult.status === "fulfilled") {
+        setLoanData(loanResult.value)
+        setLoanError(null)
+      } else {
+        const message =
+          loanResult.reason instanceof Error
+            ? loanResult.reason.message
+            : "Unable to load loan progress."
+        errors.push(message)
+        setLoanError(message)
+      }
+
+      if (timelineResult.status === "fulfilled") {
+        setTimelineStages(timelineResult.value)
+        setTimelineError(null)
+      } else {
+        const message =
+          timelineResult.reason instanceof Error
+            ? timelineResult.reason.message
+            : "Unable to load timeline stages."
+        errors.push(message)
+        setTimelineError(message)
+      }
+
+      if (costResult.status === "fulfilled") {
+        setCostFigures(costResult.value)
+        setCostError(null)
+      } else {
+        const message =
+          costResult.reason instanceof Error
+            ? costResult.reason.message
+            : "Unable to load cost breakdown data."
+        errors.push(message)
+        setCostError(message)
+      }
+
+      setGlobalError(errors.length ? errors.join(" ") : null)
+      setLoading(false)
+    }
+
+    void loadDashboardData()
+
+    return () => {
+      isMounted = false
+    }
+  }, [])
+
+  const notificationCount = user?.notificationCount ?? 0
+  const userName = user?.name ?? "Guest"
+  const userRole = user?.role ?? ""
+  const userAvatar = user?.avatarUrl ?? undefined
+
+  const loanProgress = loanData?.progress ?? 0
+  const currentStageName = loanData?.currentStageName ?? loanData?.status ?? "—"
 
   return (
     <div className="min-h-screen bg-slate-50">
-      {/* Header */}
       <header className="sticky top-0 z-10 bg-white border-b border-slate-200 shadow-sm">
         <div className="container flex items-center justify-between h-16 px-4 mx-auto">
           <div className="flex items-center space-x-4">
@@ -50,79 +146,74 @@ const HomePage = () => {
           <div className="flex items-center space-x-4">
             <Button variant="ghost" size="icon" className="relative">
               <Bell className="w-5 h-5" />
-              {user.notifications > 0 && (
+              {notificationCount > 0 && (
                 <span className="absolute top-0 right-0 w-4 h-4 text-xs text-white bg-red-500 rounded-full">
-                  {user.notifications}
+                  {notificationCount}
                 </span>
               )}
             </Button>
 
             <div className="flex items-center space-x-2">
               <Avatar>
-                <AvatarImage src={user.avatar} alt={user.name} />
-                <AvatarFallback>{user.name.charAt(0)}</AvatarFallback>
+                <AvatarImage src={userAvatar} alt={userName} />
+                <AvatarFallback>{userName.charAt(0)}</AvatarFallback>
               </Avatar>
               <div className="hidden text-sm md:block">
-                <p className="font-medium">{user.name}</p>
-                <p className="text-xs text-slate-500 capitalize">{user.role}</p>
+                <p className="font-medium">
+                  {loading ? "Loading..." : userName}
+                </p>
+                <p className="text-xs text-slate-500 capitalize">
+                  {loading
+                    ? ""
+                    : userError
+                      ? "User info unavailable"
+                      : userRole || ""}
+                </p>
               </div>
             </div>
           </div>
         </div>
       </header>
 
-      {/* Main Content */}
       <div className="container px-4 py-6 mx-auto">
+        {globalError && (
+          <Card className="mb-6 border-red-200 bg-red-50">
+            <CardContent className="flex items-center gap-2 text-sm text-red-600">
+              <AlertCircle className="h-4 w-4" />
+              <span>{globalError}</span>
+            </CardContent>
+          </Card>
+        )}
+
         <div className="grid grid-cols-12 gap-6">
-          {/* Sidebar */}
           <div className="col-span-12 md:col-span-3 lg:col-span-2">
             <div className="sticky top-20">
               <nav className="space-y-1">
-                <Button
-                  variant="ghost"
-                  className="w-full justify-start"
-                  asChild
-                >
+                <Button variant="ghost" className="w-full justify-start" asChild>
                   <div className="flex items-center space-x-2 text-blue-600">
                     <Home className="w-5 h-5" />
                     <span>Dashboard</span>
                   </div>
                 </Button>
-                <Button
-                  variant="ghost"
-                  className="w-full justify-start"
-                  asChild
-                >
+                <Button variant="ghost" className="w-full justify-start" asChild>
                   <div className="flex items-center space-x-2">
                     <FileText className="w-5 h-5" />
                     <span>Documents</span>
                   </div>
                 </Button>
-                <Button
-                  variant="ghost"
-                  className="w-full justify-start"
-                  asChild
-                >
+                <Button variant="ghost" className="w-full justify-start" asChild>
                   <div className="flex items-center space-x-2">
                     <MessageSquare className="w-5 h-5" />
                     <span>Messages</span>
                   </div>
                 </Button>
-                <Button
-                  variant="ghost"
-                  className="w-full justify-start"
-                  asChild
-                >
+                <Button variant="ghost" className="w-full justify-start" asChild>
                   <div className="flex items-center space-x-2">
                     <User className="w-5 h-5" />
                     <span>Profile</span>
                   </div>
                 </Button>
-                <Button
-                  variant="ghost"
-                  className="w-full justify-start"
-                  asChild
-                >
+                <Button variant="ghost" className="w-full justify-start" asChild>
                   <div className="flex items-center space-x-2">
                     <Settings className="w-5 h-5" />
                     <span>Settings</span>
@@ -132,21 +223,27 @@ const HomePage = () => {
             </div>
           </div>
 
-          {/* Main Content Area */}
           <div className="col-span-12 md:col-span-9 lg:col-span-10">
-            {/* Welcome Card */}
             <Card className="mb-6 bg-gradient-to-r from-blue-600 to-blue-800 text-white">
               <CardContent className="p-6">
                 <div className="flex flex-col md:flex-row justify-between items-start md:items-center">
                   <div>
                     <h2 className="text-2xl font-bold mb-2">
-                      Welcome back, {user.name}
+                      {loading ? "Welcome back" : `Welcome back, ${userName}`}
                     </h2>
                     <p className="text-blue-100">
-                      Your mortgage application is {loanData.progress}% complete
+                      {loading
+                        ? "Loading your mortgage application..."
+                        : loanError
+                          ? loanError
+                          : `Your mortgage application is ${loanProgress}% complete`}
                     </p>
                     <p className="text-blue-100 mt-1">
-                      Current stage: {loanData.currentStage}
+                      {loading
+                        ? "Retrieving current stage..."
+                        : loanError
+                          ? "Current stage unavailable."
+                          : `Current stage: ${currentStageName}`}
                     </p>
                   </div>
                   <Button className="mt-4 md:mt-0 bg-white text-blue-800 hover:bg-blue-50">
@@ -156,17 +253,21 @@ const HomePage = () => {
               </CardContent>
             </Card>
 
-            {/* Mortgage Timeline */}
             <Card className="mb-6">
               <CardHeader>
                 <CardTitle>Mortgage Timeline</CardTitle>
               </CardHeader>
               <CardContent>
-                <MortgageTimeline />
+                <MortgageTimeline
+                  stages={timelineStages}
+                  currentStageId={loanData?.currentStageId}
+                  progress={loanProgress}
+                  isLoading={loading && !timelineStages.length && !timelineError}
+                  error={timelineError}
+                />
               </CardContent>
             </Card>
 
-            {/* Tabs for other sections */}
             <Tabs defaultValue="documents" className="mb-6">
               <TabsList className="grid w-full grid-cols-3">
                 <TabsTrigger value="documents">Documents</TabsTrigger>
@@ -202,7 +303,11 @@ const HomePage = () => {
                     <CardTitle>Cost Breakdown</CardTitle>
                   </CardHeader>
                   <CardContent>
-                    <CostBreakdown />
+                    <CostBreakdown
+                      data={costFigures}
+                      isLoading={loading && !costFigures && !costError}
+                      error={costError}
+                    />
                   </CardContent>
                 </Card>
               </TabsContent>
@@ -211,7 +316,7 @@ const HomePage = () => {
         </div>
       </div>
     </div>
-  );
-};
+  )
+}
 
-export default HomePage;
+export default HomePage

--- a/src/lib/dashboard-data.ts
+++ b/src/lib/dashboard-data.ts
@@ -1,0 +1,223 @@
+import { getSupabaseClient } from "@/lib/supabaseClient"
+import type {
+  CostItem,
+  CostFigures,
+  DashboardUser,
+  LoanProgressSummary,
+  TimelineStage,
+  TimelineTask,
+} from "@/types/dashboard"
+import type {
+  CostItemRow,
+  CostSummaryRow,
+  LoanProgressRow,
+  TimelineStageRow,
+  TimelineTaskRow,
+} from "@/types/supabase"
+
+function mapTimelineTasks(tasks: TimelineTaskRow[] | null): TimelineTask[] {
+  if (!Array.isArray(tasks)) {
+    return []
+  }
+
+  return tasks.map((task) => ({
+    id: task.id,
+    name: task.name,
+    completed: Boolean(task.completed),
+    deadline: task.deadline ?? undefined,
+  }))
+}
+
+function mapTimelineStage(row: TimelineStageRow): TimelineStage {
+  return {
+    id: row.id,
+    name: row.name,
+    status: row.status,
+    description: row.description ?? "",
+    tasks: mapTimelineTasks(row.tasks),
+  }
+}
+
+function mapCostItem(row: CostItemRow): CostItem {
+  return {
+    id: row.id,
+    name: row.name,
+    amount: row.amount,
+    description: row.description ?? undefined,
+    isPaid: row.is_paid ?? undefined,
+  }
+}
+
+function resolveLoanProgress(row: LoanProgressRow | null): LoanProgressSummary | null {
+  if (!row) {
+    return null
+  }
+
+  return {
+    loanId: row.loan_id,
+    status: row.status,
+    currentStageId: row.current_stage_id,
+    currentStageName: row.current_stage_name,
+    progress: row.progress_percentage ?? 0,
+    pendingTasks: row.pending_tasks ?? 0,
+    agentName: row.agent_name,
+    lenderName: row.lender_name,
+    processorName: row.processor_name,
+    loanAmount: row.loan_amount ?? 0,
+    downPayment: row.down_payment ?? 0,
+    totalCost: row.total_cost ?? 0,
+    monthlyPayment: row.monthly_payment ?? 0,
+  }
+}
+
+function resolveCostFigures(
+  summary: CostSummaryRow | null,
+  items: CostItemRow[] | null,
+): CostFigures | null {
+  if (!summary && (!items || items.length === 0)) {
+    return null
+  }
+
+  const grouped = {
+    closing: [] as CostItem[],
+    tax: [] as CostItem[],
+    insurance: [] as CostItem[],
+    fee: [] as CostItem[],
+  }
+
+  if (items) {
+    items.forEach((item) => {
+      const key = item.category
+      if (grouped[key]) {
+        grouped[key].push(mapCostItem(item))
+      }
+    })
+  }
+
+  return {
+    loanAmount: summary?.loan_amount ?? 0,
+    downPayment: summary?.down_payment ?? 0,
+    totalCost: summary?.total_cost ?? 0,
+    monthlyPayment: summary?.monthly_payment ?? 0,
+    closingCosts: grouped.closing,
+    taxes: grouped.tax,
+    insurance: grouped.insurance,
+    fees: grouped.fee,
+  }
+}
+
+export async function fetchAuthenticatedUser(): Promise<DashboardUser | null> {
+  const supabase = getSupabaseClient()
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser()
+
+  if (error) {
+    throw error
+  }
+
+  if (!user) {
+    return null
+  }
+
+  const { data: profile, error: profileError } = await supabase
+    .from("profiles")
+    .select("full_name, avatar_url, role, notification_count")
+    .eq("id", user.id)
+    .maybeSingle()
+
+  if (profileError) {
+    throw profileError
+  }
+
+  return {
+    id: user.id,
+    email: user.email ?? null,
+    name: profile?.full_name ?? user.email ?? "",
+    role: profile?.role ?? null,
+    avatarUrl: profile?.avatar_url ?? null,
+    notificationCount: profile?.notification_count ?? 0,
+  }
+}
+
+export async function fetchLoanProgress(
+  loanId?: string,
+): Promise<LoanProgressSummary | null> {
+  const supabase = getSupabaseClient()
+  if (loanId) {
+    const { data, error } = await supabase
+      .from("loan_progress")
+      .select("*")
+      .eq("loan_id", loanId)
+      .maybeSingle()
+
+    if (error) {
+      throw error
+    }
+
+    return resolveLoanProgress(data)
+  }
+
+  const { data, error } = await supabase
+    .from("loan_progress")
+    .select("*")
+    .limit(1)
+
+  if (error) {
+    throw error
+  }
+
+  const row = Array.isArray(data) ? data[0] : null
+  return resolveLoanProgress(row ?? null)
+}
+
+export async function fetchTimelineStages(
+  loanId?: string,
+): Promise<TimelineStage[]> {
+  const supabase = getSupabaseClient()
+  let query = supabase.from("loan_timeline_stages").select("*")
+
+  if (loanId) {
+    query = query.eq("loan_id", loanId)
+  }
+
+  const { data, error } = await query.order("position", { ascending: true })
+
+  if (error) {
+    throw error
+  }
+
+  if (!data) {
+    return []
+  }
+
+  return data.map(mapTimelineStage)
+}
+
+export async function fetchCostFigures(
+  loanId?: string,
+): Promise<CostFigures | null> {
+  const supabase = getSupabaseClient()
+  let summaryQuery = supabase.from("loan_cost_summary").select("*")
+  let itemsQuery = supabase.from("loan_cost_items").select("*")
+
+  if (loanId) {
+    summaryQuery = summaryQuery.eq("loan_id", loanId)
+    itemsQuery = itemsQuery.eq("loan_id", loanId)
+  }
+
+  const [{ data: summaryData, error: summaryError }, { data: itemsData, error: itemsError }] =
+    await Promise.all([summaryQuery.limit(1), itemsQuery])
+
+  if (summaryError) {
+    throw summaryError
+  }
+
+  if (itemsError) {
+    throw itemsError
+  }
+
+  const summaryRow = Array.isArray(summaryData) ? summaryData[0] : summaryData ?? null
+  return resolveCostFigures(summaryRow ?? null, itemsData ?? null)
+}

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,0 +1,21 @@
+import { createClient, type SupabaseClient } from "@supabase/supabase-js"
+import type { Database } from "@/types/supabase"
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY
+
+let cachedClient: SupabaseClient<Database> | null = null
+
+export const getSupabaseClient = (): SupabaseClient<Database> => {
+  if (!supabaseUrl || !supabaseAnonKey) {
+    throw new Error(
+      "Missing Supabase environment variables. Please set VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY.",
+    )
+  }
+
+  if (!cachedClient) {
+    cachedClient = createClient<Database>(supabaseUrl, supabaseAnonKey)
+  }
+
+  return cachedClient
+}

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -1,0 +1,58 @@
+export type DashboardUser = {
+  id: string
+  name: string
+  role: string | null
+  email: string | null
+  avatarUrl: string | null
+  notificationCount: number
+}
+
+export type LoanProgressSummary = {
+  loanId: string
+  status: string | null
+  currentStageId: string | null
+  currentStageName: string | null
+  progress: number
+  pendingTasks: number
+  agentName: string | null
+  lenderName: string | null
+  processorName: string | null
+  loanAmount: number
+  downPayment: number
+  totalCost: number
+  monthlyPayment: number
+}
+
+export type TimelineTask = {
+  id: string
+  name: string
+  completed: boolean
+  deadline?: string | null
+}
+
+export type TimelineStage = {
+  id: string
+  name: string
+  status: "completed" | "in-progress" | "pending"
+  tasks: TimelineTask[]
+  description: string
+}
+
+export type CostItem = {
+  id?: string
+  name: string
+  amount: number
+  description?: string | null
+  isPaid?: boolean | null
+}
+
+export type CostFigures = {
+  loanAmount: number
+  downPayment: number
+  closingCosts: CostItem[]
+  taxes: CostItem[]
+  insurance: CostItem[]
+  fees: CostItem[]
+  totalCost: number
+  monthlyPayment: number
+}

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -1,0 +1,86 @@
+export type ProfileRow = {
+  id: string
+  full_name: string | null
+  avatar_url: string | null
+  role: string | null
+  notification_count: number | null
+}
+
+export type LoanProgressRow = {
+  id: string
+  loan_id: string
+  status: string | null
+  current_stage_id: string | null
+  current_stage_name: string | null
+  progress_percentage: number | null
+  pending_tasks: number | null
+  agent_name: string | null
+  lender_name: string | null
+  processor_name: string | null
+  loan_amount: number | null
+  down_payment: number | null
+  total_cost: number | null
+  monthly_payment: number | null
+}
+
+export type TimelineTaskRow = {
+  id: string
+  name: string
+  completed: boolean | null
+  deadline: string | null
+}
+
+export type TimelineStageRow = {
+  id: string
+  loan_id: string
+  name: string
+  status: "completed" | "in-progress" | "pending"
+  description: string | null
+  tasks: TimelineTaskRow[] | null
+  position: number | null
+}
+
+export type CostItemRow = {
+  id: string
+  loan_id: string
+  category: "closing" | "tax" | "insurance" | "fee"
+  name: string
+  amount: number
+  description: string | null
+  is_paid: boolean | null
+}
+
+export type CostSummaryRow = {
+  loan_id: string
+  loan_amount: number | null
+  down_payment: number | null
+  total_cost: number | null
+  monthly_payment: number | null
+}
+
+export type Database = {
+  public: {
+    Tables: {
+      profiles: {
+        Row: ProfileRow
+      }
+      loan_progress: {
+        Row: LoanProgressRow
+      }
+      loan_timeline_stages: {
+        Row: TimelineStageRow
+      }
+      loan_cost_items: {
+        Row: CostItemRow
+      }
+    }
+    Views: {
+      loan_cost_summary: {
+        Row: CostSummaryRow
+      }
+    }
+    Functions: Record<string, never>
+    Enums: Record<string, never>
+    CompositeTypes: Record<string, never>
+  }
+}


### PR DESCRIPTION
## Summary
- add Supabase client helper, dashboard data-fetching utilities, and shared dashboard types
- refactor the home dashboard to load Supabase data, propagate loading/error states, and surface warnings in the UI
- update MortgageTimeline and CostBreakdown components to consume fetched data and drop hard-coded mock content

## Testing
- npm run lint *(fails: ESLint config missing in repository)*
- npm run build *(passes but `tsc` warns about missing `tempo-routes` module from existing setup)*

------
https://chatgpt.com/codex/tasks/task_e_68e17ee1dbd483288b519711aa1b2979