### PR TITLE
Integrate Supabase authentication flow

### DIFF
--- a/src/components/security/AuthProvider.tsx
+++ b/src/components/security/AuthProvider.tsx
@@ -1,25 +1,72 @@
-import React, { createContext, useContext, useState, useEffect } from 'react';
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import type { Session } from '@supabase/supabase-js';
+import { supabase } from '@/lib/supabaseClient';
 
-interface User {
+export type Role =
+  | 'homebuyer'
+  | 'agent'
+  | 'lender'
+  | 'processor'
+  | 'admin';
+
+type FactorType = 'totp' | 'phone';
+
+type RolePermissions = Record<Role, string[]>;
+
+const ROLE_PERMISSIONS: RolePermissions = {
+  homebuyer: ['view_own_timeline', 'upload_documents', 'send_messages', 'view_own_costs'],
+  agent: ['view_client_timelines', 'manage_listings', 'send_messages', 'view_client_documents'],
+  lender: ['view_loan_applications', 'access_financial_documents', 'update_approval_status', 'send_messages'],
+  processor: ['process_documents', 'update_timelines', 'manage_deadlines', 'send_messages'],
+  admin: ['full_access', 'manage_users', 'view_audit_logs', 'system_settings'],
+};
+
+const KNOWN_ROLES: Role[] = ['homebuyer', 'agent', 'lender', 'processor', 'admin'];
+
+const isRole = (value: unknown): value is Role =>
+  typeof value === 'string' && (KNOWN_ROLES as string[]).includes(value);
+
+export interface AppUser {
   id: string;
   email: string;
   firstName: string;
   lastName: string;
-  role: 'homebuyer' | 'agent' | 'lender' | 'processor' | 'admin';
+  role: Role;
   permissions: string[];
   mfaEnabled: boolean;
   lastLogin?: string;
   sessionExpiry: number;
 }
 
+export interface LoginResult {
+  success: boolean;
+  mfaRequired?: boolean;
+  error?: string;
+}
+
+interface MfaChallenge {
+  factorId: string;
+  factorType: FactorType;
+  challengeId: string;
+}
+
 interface AuthContextType {
-  user: User | null;
-  login: (email: string, password: string, mfaCode?: string) => Promise<boolean>;
-  logout: () => void;
+  user: AppUser | null;
+  login: (email: string, password: string, mfaCode?: string) => Promise<LoginResult>;
+  logout: () => Promise<void>;
   isAuthenticated: boolean;
   hasPermission: (permission: string) => boolean;
   sessionTimeRemaining: number;
-  refreshSession: () => void;
+  refreshSession: () => Promise<void>;
+  mfaRequired: boolean;
+  resetMfa: () => void;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -36,131 +83,240 @@ interface AuthProviderProps {
   children: React.ReactNode;
 }
 
-export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
-  const [user, setUser] = useState<User | null>(null);
-  const [sessionTimeRemaining, setSessionTimeRemaining] = useState(0);
+const extractUserFromSession = (session: Session): AppUser => {
+  const { user, expires_at } = session;
+  const metadata = user?.user_metadata ?? {};
+  const roleFromMetadata = metadata.role ?? metadata.userRole ?? user?.role;
+  const role: Role = isRole(roleFromMetadata) ? roleFromMetadata : 'homebuyer';
 
-  // Role-based permissions mapping
-  const rolePermissions = {
-    homebuyer: ['view_own_timeline', 'upload_documents', 'send_messages', 'view_own_costs'],
-    agent: ['view_client_timelines', 'manage_listings', 'send_messages', 'view_client_documents'],
-    lender: ['view_loan_applications', 'access_financial_documents', 'update_approval_status', 'send_messages'],
-    processor: ['process_documents', 'update_timelines', 'manage_deadlines', 'send_messages'],
-    admin: ['full_access', 'manage_users', 'view_audit_logs', 'system_settings']
+  const permissionsFromMetadata = Array.isArray(metadata.permissions)
+    ? metadata.permissions.filter((permission: unknown): permission is string => typeof permission === 'string')
+    : null;
+
+  const expiresAtMs = (expires_at ?? Math.floor(Date.now() / 1000)) * 1000;
+
+  return {
+    id: user.id,
+    email: user.email ?? metadata.email ?? '',
+    firstName: metadata.firstName ?? metadata.first_name ?? '',
+    lastName: metadata.lastName ?? metadata.last_name ?? '',
+    role,
+    permissions: permissionsFromMetadata?.length ? permissionsFromMetadata : ROLE_PERMISSIONS[role],
+    mfaEnabled: Boolean(
+      metadata.mfaEnabled ??
+        metadata.mfa_enabled ??
+        (Array.isArray((user as { factors?: Array<{ factor_type?: string }> }).factors)
+          ? (user as { factors?: Array<{ factor_type?: string }> }).factors!.length > 0
+          : false),
+    ),
+    lastLogin: user.last_sign_in_at ?? undefined,
+    sessionExpiry: expiresAtMs,
   };
+};
 
-  useEffect(() => {
-    // Check for existing session on mount
-    const storedUser = sessionStorage.getItem('hipotrack_user');
-    if (storedUser) {
-      const userData = JSON.parse(storedUser);
-      if (userData.sessionExpiry > Date.now()) {
-        setUser(userData);
-        setSessionTimeRemaining(userData.sessionExpiry - Date.now());
-      } else {
-        sessionStorage.removeItem('hipotrack_user');
-      }
+export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
+  const [user, setUser] = useState<AppUser | null>(null);
+  const [sessionTimeRemaining, setSessionTimeRemaining] = useState(0);
+  const [mfaChallenge, setMfaChallenge] = useState<MfaChallenge | null>(null);
+
+  const handleSession = useCallback((session: Session | null) => {
+    if (session?.user) {
+      const mappedUser = extractUserFromSession(session);
+      setUser(mappedUser);
+      const remaining = Math.max(mappedUser.sessionExpiry - Date.now(), 0);
+      setSessionTimeRemaining(remaining);
+    } else {
+      setUser(null);
+      setSessionTimeRemaining(0);
     }
   }, []);
 
   useEffect(() => {
-    // Session countdown timer
-    if (user && sessionTimeRemaining > 0) {
-      const timer = setInterval(() => {
-        setSessionTimeRemaining(prev => {
-          if (prev <= 1000) {
-            logout();
-            return 0;
-          }
-          return prev - 1000;
-        });
-      }, 1000);
+    const initialiseSession = async () => {
+      const { data, error } = await supabase.auth.getSession();
+      if (error) {
+        console.error('Failed to retrieve session:', error);
+        return;
+      }
+      handleSession(data.session ?? null);
+    };
 
-      return () => clearInterval(timer);
-    }
-  }, [user, sessionTimeRemaining]);
+    void initialiseSession();
 
-  const login = async (email: string, password: string, mfaCode?: string): Promise<boolean> => {
-    try {
-      // Simulate API call with security checks
-      console.log('Authenticating user:', email);
-      
-      // Mock user data - in real app, this comes from secure backend
-      const mockUser: User = {
-        id: '1',
-        email,
-        firstName: 'John',
-        lastName: 'Doe',
-        role: 'homebuyer',
-        permissions: rolePermissions.homebuyer,
-        mfaEnabled: true,
-        lastLogin: new Date().toISOString(),
-        sessionExpiry: Date.now() + (30 * 60 * 1000) // 30 minutes
-      };
-
-      // Store in secure session storage (in production, use HTTP-only cookies)
-      sessionStorage.setItem('hipotrack_user', JSON.stringify(mockUser));
-      setUser(mockUser);
-      setSessionTimeRemaining(30 * 60 * 1000);
-
-      // Log security event
-      console.log('Security Event: User login successful', {
-        userId: mockUser.id,
-        timestamp: new Date().toISOString(),
-        ip: 'xxx.xxx.xxx.xxx' // Would be actual IP
-      });
-
-      return true;
-    } catch (error) {
-      console.error('Login failed:', error);
-      return false;
-    }
-  };
-
-  const logout = () => {
-    // Clear session data
-    sessionStorage.removeItem('hipotrack_user');
-    setUser(null);
-    setSessionTimeRemaining(0);
-
-    // Log security event
-    console.log('Security Event: User logout', {
-      timestamp: new Date().toISOString()
+    const { data } = supabase.auth.onAuthStateChange((_event, session) => {
+      handleSession(session);
+      if (!session) {
+        setMfaChallenge(null);
+      }
     });
-  };
 
-  const hasPermission = (permission: string): boolean => {
-    if (!user) return false;
-    return user.permissions.includes(permission) || user.permissions.includes('full_access');
-  };
+    return () => {
+      data.subscription.unsubscribe();
+    };
+  }, [handleSession]);
 
-  const refreshSession = () => {
-    if (user) {
-      const updatedUser = {
-        ...user,
-        sessionExpiry: Date.now() + (30 * 60 * 1000)
-      };
-      sessionStorage.setItem('hipotrack_user', JSON.stringify(updatedUser));
-      setUser(updatedUser);
-      setSessionTimeRemaining(30 * 60 * 1000);
+  useEffect(() => {
+    if (!user?.sessionExpiry) {
+      setSessionTimeRemaining(0);
+      return;
     }
-  };
 
-  const value: AuthContextType = {
-    user,
-    login,
-    logout,
-    isAuthenticated: !!user,
-    hasPermission,
-    sessionTimeRemaining,
-    refreshSession
-  };
+    const updateRemaining = () => {
+      const remaining = Math.max(user.sessionExpiry - Date.now(), 0);
+      setSessionTimeRemaining(remaining);
+    };
 
-  return (
-    <AuthContext.Provider value={value}>
-      {children}
-    </AuthContext.Provider>
+    updateRemaining();
+    const interval = window.setInterval(updateRemaining, 1000);
+
+    return () => {
+      window.clearInterval(interval);
+    };
+  }, [user?.sessionExpiry]);
+
+  const login = useCallback(
+    async (email: string, password: string, mfaCode?: string): Promise<LoginResult> => {
+      if (mfaCode) {
+        if (!mfaChallenge) {
+          return {
+            success: false,
+            error: 'No MFA challenge is active. Please try signing in again.',
+          };
+        }
+
+        const { error } = await supabase.auth.mfa.verify({
+          factorId: mfaChallenge.factorId,
+          challengeId: mfaChallenge.challengeId,
+          code: mfaCode,
+        });
+
+        if (error) {
+          console.error('MFA verification failed:', error);
+          return {
+            success: false,
+            mfaRequired: true,
+            error: error.message ?? 'Invalid authentication code.',
+          };
+        }
+
+        setMfaChallenge(null);
+        const { data: sessionData, error: sessionError } = await supabase.auth.getSession();
+        if (sessionError) {
+          console.error('Failed to retrieve session after MFA verification:', sessionError);
+          return {
+            success: false,
+            error: 'Authentication succeeded but session retrieval failed. Please try again.',
+          };
+        }
+
+        handleSession(sessionData.session ?? null);
+        return { success: true };
+      }
+
+      setMfaChallenge(null);
+      const { data, error } = await supabase.auth.signInWithPassword({ email, password });
+
+      if (error) {
+        const errorMessage = error.message ?? 'Unable to sign in. Please check your credentials.';
+        const isMfaError = errorMessage.toLowerCase().includes('mfa');
+        const factor =
+          data?.user &&
+          Array.isArray((data.user as { factors?: Array<{ id: string; factor_type: string }> }).factors)
+            ? (data.user as { factors?: Array<{ id: string; factor_type: string }> }).factors!.find(
+                ({ factor_type }) => factor_type === 'totp' || factor_type === 'phone',
+              )
+            : undefined;
+
+        if (isMfaError && factor) {
+          const factorType: FactorType = factor.factor_type === 'phone' ? 'phone' : 'totp';
+          const { data: challengeData, error: challengeError } = await supabase.auth.mfa.challenge({
+            factorId: factor.id,
+            ...(factorType === 'phone' ? { channel: 'sms' as const } : {}),
+          });
+
+          if (challengeError || !challengeData) {
+            console.error('MFA challenge creation failed:', challengeError);
+            return {
+              success: false,
+              error: 'Unable to start multi-factor authentication. Please try again.',
+            };
+          }
+
+          setMfaChallenge({
+            factorId: factor.id,
+            factorType,
+            challengeId: challengeData.id,
+          });
+
+          return {
+            success: false,
+            mfaRequired: true,
+            error: 'Multi-factor authentication required. Enter the verification code from your authenticator.',
+          };
+        }
+
+        console.error('Sign-in failed:', error);
+        return {
+          success: false,
+          error: errorMessage,
+        };
+      }
+
+      handleSession(data.session ?? null);
+      return { success: true };
+    },
+    [handleSession, mfaChallenge],
   );
+
+  const refreshSession = useCallback(async () => {
+    const { data, error } = await supabase.auth.refreshSession();
+    if (error) {
+      console.error('Session refresh failed:', error);
+      await supabase.auth.signOut();
+      handleSession(null);
+      return;
+    }
+
+    handleSession(data.session ?? null);
+  }, [handleSession]);
+
+  const logout = useCallback(async () => {
+    const { error } = await supabase.auth.signOut();
+    if (error) {
+      console.error('Logout failed:', error);
+    }
+    setMfaChallenge(null);
+    handleSession(null);
+  }, [handleSession]);
+
+  const resetMfa = useCallback(() => {
+    setMfaChallenge(null);
+  }, []);
+
+  const hasPermission = useCallback(
+    (permission: string): boolean => {
+      if (!user) return false;
+      return user.permissions.includes(permission) || user.permissions.includes('full_access');
+    },
+    [user],
+  );
+
+  const contextValue = useMemo<AuthContextType>(
+    () => ({
+      user,
+      login,
+      logout,
+      isAuthenticated: !!user,
+      hasPermission,
+      sessionTimeRemaining,
+      refreshSession,
+      mfaRequired: !!mfaChallenge,
+      resetMfa,
+    }),
+    [hasPermission, login, logout, mfaChallenge, refreshSession, resetMfa, sessionTimeRemaining, user],
+  );
+
+  return <AuthContext.Provider value={contextValue}>{children}</AuthContext.Provider>;
 };
 
 export default AuthProvider;

--- a/src/components/security/LoginForm.tsx
+++ b/src/components/security/LoginForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -23,7 +23,7 @@ interface LoginFormProps {
 }
 
 const LoginForm: React.FC<LoginFormProps> = ({ onSuccess }) => {
-  const { login } = useAuth();
+  const { login, mfaRequired, resetMfa } = useAuth();
   const [formData, setFormData] = useState({
     email: '',
     password: '',
@@ -34,6 +34,13 @@ const LoginForm: React.FC<LoginFormProps> = ({ onSuccess }) => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const [loginAttempts, setLoginAttempts] = useState(0);
+
+  useEffect(() => {
+    setShowMFA(mfaRequired);
+    if (!mfaRequired) {
+      setFormData((prev) => ({ ...prev, mfaCode: '' }));
+    }
+  }, [mfaRequired]);
 
   const passwordStrength = (password: string) => {
     let strength = 0;
@@ -70,29 +77,31 @@ const LoginForm: React.FC<LoginFormProps> = ({ onSuccess }) => {
     }
 
     try {
-      // First step: email/password
-      if (!showMFA) {
-        // Simulate checking credentials
-        if (formData.email && formData.password) {
-          setShowMFA(true);
-          setLoading(false);
-          return;
-        }
+      const result = await login(
+        formData.email,
+        formData.password,
+        showMFA ? formData.mfaCode : undefined,
+      );
+
+      if (result.success) {
+        onSuccess?.();
+        return;
       }
 
-      // Second step: MFA verification
-      const success = await login(formData.email, formData.password, formData.mfaCode);
-      
-      if (success) {
-        onSuccess?.();
-      } else {
-        setLoginAttempts(prev => prev + 1);
-        setError('Invalid credentials or MFA code. Please try again.');
-        setShowMFA(false);
+      if (result.mfaRequired) {
+        if (showMFA) {
+          setLoginAttempts((prev) => prev + 1);
+        }
+        setShowMFA(true);
+        setError(result.error ?? 'Multi-factor authentication required. Enter your code.');
+        return;
       }
+
+      setLoginAttempts((prev) => prev + 1);
+      setError(result.error ?? 'Login failed. Please try again.');
     } catch (err) {
-      setError('Login failed. Please try again.');
-      setLoginAttempts(prev => prev + 1);
+      setLoginAttempts((prev) => prev + 1);
+      setError(err instanceof Error ? err.message : 'Login failed. Please try again.');
     } finally {
       setLoading(false);
     }
@@ -226,27 +235,30 @@ const LoginForm: React.FC<LoginFormProps> = ({ onSuccess }) => {
             )}
 
             {/* Submit Button */}
-            <Button 
-              type="submit" 
-              className="w-full" 
-              disabled={loading || loginAttempts >= 5}
+            <Button
+              type="submit"
+              className="w-full"
+              disabled={
+                loading ||
+                loginAttempts >= 5 ||
+                (showMFA && formData.mfaCode.length < 6)
+              }
             >
-              {loading ? (
-                'Authenticating...'
-              ) : showMFA ? (
-                'Verify & Login'
-              ) : (
-                'Continue to MFA'
-              )}
+              {loading ? 'Authenticating...' : showMFA ? 'Verify & Login' : 'Sign In'}
             </Button>
 
             {/* Back Button for MFA */}
             {showMFA && (
-              <Button 
-                type="button" 
-                variant="outline" 
+              <Button
+                type="button"
+                variant="outline"
                 className="w-full"
-                onClick={() => setShowMFA(false)}
+                onClick={() => {
+                  resetMfa();
+                  setShowMFA(false);
+                  setFormData((prev) => ({ ...prev, mfaCode: '' }));
+                  setError('');
+                }}
               >
                 Back to Login
               </Button>

--- a/src/components/security/SecurityDashboard.tsx
+++ b/src/components/security/SecurityDashboard.tsx
@@ -108,19 +108,19 @@ const SecurityDashboard: React.FC = () => {
               </div>
 
               <div className="flex gap-2">
-                <Button 
-                  variant="outline" 
-                  size="sm" 
-                  onClick={refreshSession}
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => void refreshSession()}
                   className="flex-1"
                 >
                   <RefreshCw className="h-4 w-4 mr-1" />
                   Extend
                 </Button>
-                <Button 
-                  variant="destructive" 
-                  size="sm" 
-                  onClick={logout}
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  onClick={() => void logout()}
                   className="flex-1"
                 >
                   <LogOut className="h-4 w-4 mr-1" />

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,0 +1,23 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl) {
+  throw new Error('VITE_SUPABASE_URL is not defined.');
+}
+
+if (!supabaseAnonKey) {
+  throw new Error('VITE_SUPABASE_ANON_KEY is not defined.');
+}
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+  auth: {
+    persistSession: true,
+    autoRefreshToken: true,
+    detectSessionInUrl: true,
+    storageKey: 'hipotrack.supabase.auth',
+  },
+});
+
+export default supabase;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom/client";
 import App from "./App.tsx";
 import "./index.css";
 import { BrowserRouter } from "react-router-dom";
+import { AuthProvider } from "./components/security/AuthProvider";
 
 /* import { TempoDevtools } from 'tempo-devtools'; [deprecated] */
 /* TempoDevtools.init() [deprecated] */;
@@ -12,7 +13,9 @@ const basename = import.meta.env.BASE_URL;
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <BrowserRouter basename={basename}>
-      <App />
+      <AuthProvider>
+        <App />
+      </AuthProvider>
     </BrowserRouter>
   </React.StrictMode>,
 );

--- a/src/types/tempo-routes.d.ts
+++ b/src/types/tempo-routes.d.ts
@@ -1,0 +1,6 @@
+declare module "tempo-routes" {
+  import type { RouteObject } from "react-router-dom";
+
+  const routes: RouteObject[];
+  export default routes;
+}


### PR DESCRIPTION
## Summary
- add a Supabase client helper that reads Vite environment settings
- replace the AuthProvider mock auth logic with Supabase-based session, MFA, and refresh handling
- update the login flow and app wiring to consume the new context and ensure async handlers are awaited
- add a type declaration for tempo-routes to satisfy the TypeScript build

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e17ee0cb6c8328b9b553f61c78594a